### PR TITLE
feat(be): 엔티티 기본 구현

### DIFF
--- a/backend/src/main/java/com/back/ourlog/Application.java
+++ b/backend/src/main/java/com/back/ourlog/Application.java
@@ -2,7 +2,9 @@ package com.back.ourlog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
 

--- a/backend/src/main/java/com/back/ourlog/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/back/ourlog/domain/comment/entity/Comment.java
@@ -1,0 +1,46 @@
+package com.back.ourlog.domain.comment.entity;
+
+import com.back.ourlog.domain.diary.entity.Diary;
+import com.back.ourlog.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String content;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public Comment(Diary diary, User user, String content) {
+        this.diary = diary;
+        this.user = user;
+        this.content = content;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/content/entity/Content.java
+++ b/backend/src/main/java/com/back/ourlog/domain/content/entity/Content.java
@@ -1,0 +1,54 @@
+package com.back.ourlog.domain.content.entity;
+
+import com.back.ourlog.domain.diary.entity.Diary;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Content {
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    private Integer id;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ContentType type;
+
+    private String description;
+    private String posterUrl;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime releasedAt;
+    private String externalId;
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Diary> diaries = new ArrayList<>();
+
+    public Content(String title, ContentType type, String description, String posterUrl, LocalDateTime releasedAt, String externalId) {
+        this.title = title;
+        this.type = type;
+        this.description = description;
+        this.posterUrl = posterUrl;
+        this.releasedAt = releasedAt;
+        this.externalId = externalId;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/content/entity/ContentType.java
+++ b/backend/src/main/java/com/back/ourlog/domain/content/entity/ContentType.java
@@ -1,0 +1,5 @@
+package com.back.ourlog.domain.content.entity;
+
+public enum ContentType {
+    MOVIE, BOOK, MUSIC
+}

--- a/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
@@ -1,0 +1,73 @@
+package com.back.ourlog.domain.diary.entity;
+
+import com.back.ourlog.domain.comment.entity.Comment;
+import com.back.ourlog.domain.content.entity.Content;
+import com.back.ourlog.domain.genre.entity.DiaryGenre;
+import com.back.ourlog.domain.like.entity.Like;
+import com.back.ourlog.domain.ott.entity.DiaryOtt;
+import com.back.ourlog.domain.tag.entity.DiaryTag;
+import com.back.ourlog.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Diary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id", nullable = false)
+    private Content content;
+
+    private String title;
+    private String contentText;
+    private Float rating;
+    private Boolean isPublic;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Like> likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryTag> diaryTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryGenre> diaryGenres = new ArrayList<>();
+
+    @OneToMany(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryOtt> diaryOtts = new ArrayList<>();
+
+    public Diary(User user, Content content, String title, String contentText, Float rating, Boolean isPublic) {
+        this.user = user;
+        this.content = content;
+        this.title = title;
+        this.contentText = contentText;
+        this.rating = rating;
+        this.isPublic = isPublic;
+    }
+
+}

--- a/backend/src/main/java/com/back/ourlog/domain/follow/entity/Follow.java
+++ b/backend/src/main/java/com/back/ourlog/domain/follow/entity/Follow.java
@@ -1,0 +1,37 @@
+package com.back.ourlog.domain.follow.entity;
+
+import com.back.ourlog.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = jakarta.persistence.FetchType.LAZY)
+    @JoinColumn(name = "following_id", nullable = false)
+    private User following;
+
+    @ManyToOne(fetch = jakarta.persistence.FetchType.LAZY)
+    @JoinColumn(name = "followee_id", nullable = false)
+    private User followee;
+
+    public Follow(User following, User followee) {
+        this.following = following;
+        this.followee = followee;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenre.java
+++ b/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenre.java
@@ -1,0 +1,28 @@
+package com.back.ourlog.domain.genre.entity;
+
+import com.back.ourlog.domain.diary.entity.Diary;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@IdClass(DiaryGenreId.class)
+public class DiaryGenre {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "genre_id", nullable = false)
+    private Genre genre;
+
+    public DiaryGenre(Diary diary, Genre genre) {
+        this.diary = diary;
+        this.genre = genre;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenreId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenreId.java
@@ -1,0 +1,29 @@
+package com.back.ourlog.domain.genre.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryGenreId implements Serializable {
+    private Integer diary;
+    private Integer genre;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DiaryGenreId)) return false;
+        DiaryGenreId that = (DiaryGenreId) o;
+        return Objects.equals(diary, that.diary) && Objects.equals(genre, that.genre);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(diary, genre);
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/genre/entity/Genre.java
+++ b/backend/src/main/java/com/back/ourlog/domain/genre/entity/Genre.java
@@ -1,0 +1,26 @@
+package com.back.ourlog.domain.genre.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Genre {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "genre", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryGenre> diaryGenres = new ArrayList<>();
+
+    public Genre(String name) {
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/like/entity/Like.java
+++ b/backend/src/main/java/com/back/ourlog/domain/like/entity/Like.java
@@ -1,0 +1,40 @@
+package com.back.ourlog.domain.like.entity;
+
+import com.back.ourlog.domain.diary.entity.Diary;
+import com.back.ourlog.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "likes")
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public Like(Diary diary, User user) {
+        this.diary = diary;
+        this.user = user;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOtt.java
+++ b/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOtt.java
@@ -1,0 +1,28 @@
+package com.back.ourlog.domain.ott.entity;
+
+import com.back.ourlog.domain.diary.entity.Diary;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@IdClass(DiaryOttId.class)
+public class DiaryOtt {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ott_id", nullable = false)
+    private Ott ott;
+
+    public DiaryOtt(Diary diary, Ott ott) {
+        this.diary = diary;
+        this.ott = ott;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOttId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOttId.java
@@ -1,0 +1,29 @@
+package com.back.ourlog.domain.ott.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryOttId implements Serializable {
+    private Integer diary;
+    private Integer ott;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DiaryOttId)) return false;
+        DiaryOttId that = (DiaryOttId) o;
+        return Objects.equals(diary, that.diary) && Objects.equals(ott, that.ott);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(diary, ott);
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/ott/entity/Ott.java
+++ b/backend/src/main/java/com/back/ourlog/domain/ott/entity/Ott.java
@@ -1,0 +1,29 @@
+package com.back.ourlog.domain.ott.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Ott {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+    private String logoUrl;
+
+    @OneToMany(mappedBy = "ott", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryOtt> diaryOtts = new ArrayList<>();
+
+    public Ott(String name, String logoUrl) {
+        this.name = name;
+        this.logoUrl = logoUrl;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTag.java
+++ b/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTag.java
@@ -1,0 +1,28 @@
+package com.back.ourlog.domain.tag.entity;
+
+import com.back.ourlog.domain.diary.entity.Diary;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@IdClass(DiaryTagId.class)
+public class DiaryTag {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    public DiaryTag(Diary diary, Tag tag) {
+        this.diary = diary;
+        this.tag = tag;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTagId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTagId.java
@@ -1,0 +1,30 @@
+package com.back.ourlog.domain.tag.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryTagId implements Serializable {
+    private Integer diary;
+    private Integer tag;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DiaryTagId)) return false;
+        DiaryTagId that = (DiaryTagId) o;
+        return Objects.equals(diary, that.diary) && Objects.equals(tag, that.tag);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(diary, tag);
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/tag/entity/Tag.java
+++ b/backend/src/main/java/com/back/ourlog/domain/tag/entity/Tag.java
@@ -1,0 +1,28 @@
+package com.back.ourlog.domain.tag.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiaryTag> diaryTags = new ArrayList<>();
+
+    public Tag(String name) {
+        this.name = name;
+    }
+}
+

--- a/backend/src/main/java/com/back/ourlog/domain/user/entity/Role.java
+++ b/backend/src/main/java/com/back/ourlog/domain/user/entity/Role.java
@@ -1,7 +1,14 @@
 package com.back.ourlog.domain.user.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Role {
+    USER("ROLE_USER", "일반 사용자"),
+    ADMIN("ROLE_ADMIN", "관리자");
 
-
-
+    private final String key;        // 스프링 시큐리티에서 사용되는 실제 권한명
+    private final String description; // 권한 설명
 }

--- a/backend/src/main/java/com/back/ourlog/domain/user/entity/User.java
+++ b/backend/src/main/java/com/back/ourlog/domain/user/entity/User.java
@@ -1,24 +1,74 @@
 package com.back.ourlog.domain.user.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.back.ourlog.domain.comment.entity.Comment;
+import com.back.ourlog.domain.diary.entity.Diary;
+import com.back.ourlog.domain.follow.entity.Follow;
+import com.back.ourlog.domain.like.entity.Like;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
-@RequiredArgsConstructor
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "users")
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @Column(nullable = false, unique = true)
     private String email;
+
     private String password;
+
+    @Column(nullable = false, length = 50)
     private String nickname;
+
     private String profileImageUrl;
     private String bio;
-    private String createdAt;
-    private String updatedAt;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Role role;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Diary> diaries = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Like> likes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followingList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "followee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followeeList = new ArrayList<>();
+
+    public User(String email, String password, String nickname, String profileImageUrl, String bio, Role role) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.bio = bio;
+        this.role = role;
+    }
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 기본 엔티티 구현
- DiaryTag, DiaryOtt, DiaryGenre 중간 테이블 구현 (@IdClass 기반 복합키 방식)
- 엔티티 간 연관관계 설정

## 📌 참고 사항
- 추후 중간 테이블에 필드 추가할 경우, @EmbeddedId 방식과의 차이 고려해 리팩토링 가능
- Like 엔티티는 @Table(name = "likes")로 예약어 회피