### PR TITLE
infra: fix (#30)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-      day: "sunday"
-      time: "19:00"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Seoul"
     commit-message:
       prefix: "deps(frontend)"
     groups:
@@ -17,8 +18,9 @@ updates:
     directory: "/backend"
     schedule:
       interval: "weekly"
-      day: "sunday"
-      time: "19:00"
+      day: "monday"
+      time: "04:00"
+      timezone: "Asia/Seoul"
     commit-message:
       prefix: "deps(backend)"
     groups:

--- a/backend/src/main/java/com/back/ourlog/Application.java
+++ b/backend/src/main/java/com/back/ourlog/Application.java
@@ -2,9 +2,8 @@ package com.back.ourlog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
+// @WebMvcTest 컨트롤러 단위 테스트를 위해 JPA Auditing 기능을 JpaAuditingConfig을 통해 따로 활성화합니다. @EnableJpaAuditing
 @SpringBootApplication
 public class Application {
 

--- a/backend/src/main/java/com/back/ourlog/global/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/back/ourlog/global/config/JpaAuditingConfig.java
@@ -1,0 +1,22 @@
+package com.back.ourlog.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing // JPA Auditing 기능을 여기서 활성화합니다.
+public class JpaAuditingConfig {
+    // 필요한 경우, Auditing 관련 추가적인 Bean 정의를 이곳에 할 수 있습니다.
+    // 예를 들어, @CreatedBy, @LastModifiedBy 필드에 사용자 ID 등을 주입하려면
+    // AuditorAware 인터페이스 구현체를 여기에 Bean으로 등록할 수 있습니다.
+
+    // 단위 테스트 시
+    //  @WebMvcTest(controllers = CartController.class,
+    //        excludeFilters = {
+    //                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JpaAuditingConfig.class)
+    //        })
+    //  class CartControllerTest { }
+    // 이런 식으로 JpaAuditingConfig.class을 비활성화하여 @WebMvcTest 어노테이션을 사용하면
+    // 웹 계층 테스트에 필요한 최소한의 빈만 로드하고, JPA Auditing 관련
+    // 빈 로딩 시 발생하는 오류를 피할 수 있습니다
+}


### PR DESCRIPTION
Spring 공식 문서와 실무 가이드 모두 @EnableJpaAuditing을 @SpringBootApplication에서 분리하는 방식을 권장하고 있습니다.

왜 공식적으로 분리를 권장할까?
관심사 분리 (Separation of Concerns)

@SpringBootApplication은 애플리케이션 부트스트랩 역할만 해야 함

JPA Auditing은 데이터 계층 관련 설정이므로 별도의 @Configuration 클래스로 분리하는 게 더 명확

슬라이스 테스트(@WebMvcTest)와 충돌 방지

@EnableJpaAuditing은 JpaMetamodelMappingContext가 필요한데,
@WebMvcTest는 JPA 빈을 로드하지 않음 → JPA metamodel must not be empty 오류 발생

별도 Config로 분리하면 excludeFilters나 excludeAutoConfiguration으로 손쉽게 제외 가능

추후 확장성

AuditorAware 같은 추가 Bean을 쉽게 정의할 수 있음

특정 환경에서만 JPA Auditing을 활성화하거나 비활성화하기도 더 쉬움