### PR TITLE
feat(be): 감상일기 등록 API 구현 (#33)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/diary/controller/DiaryController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/controller/DiaryController.java
@@ -32,13 +32,8 @@ public class DiaryController {
     ) {
         Diary diary = diaryService.write(req, null); // 유저 인증 붙으면 'null' 대신 유저 넘기기
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(
-                new RsData<>(
-                        "201-1",
-                        "감상일기가 등록되었습니다.",
-                        DiaryResponseDto.from(diary)
-                )
-        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(RsData.of("201-1", "감상일기가 등록되었습니다.", DiaryResponseDto.from(diary)));
 
     }
 

--- a/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryWriteRequestDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryWriteRequestDto.java
@@ -6,8 +6,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record DiaryWriteRequestDto(
-        @NotBlank String title,
-        @NotBlank String contentText,
+        @NotBlank(message = "제목을 입력해주세요.")
+        String title,
+
+        @NotBlank(message = "내용을 입력해주세요.")
+        String contentText,
+
         @NotNull Boolean isPublic,
         @NotNull Double rating,
         @NotBlank String externalId,
@@ -15,4 +19,21 @@ public record DiaryWriteRequestDto(
         List<Integer> tagIds,
         List<Integer> genreIds,
         List<Integer> ottIds
-) {}
+) {
+
+    // 테스트용 생성자
+    public DiaryWriteRequestDto(String title, String contentText) {
+        this(
+                title,
+                contentText,
+                true,
+                4.5,
+                "external-id-test",
+                ContentType.MOVIE,
+                List.of(1, 2),
+                List.of(1, 2),
+                List.of(1, 2)
+        );
+    }
+
+}

--- a/backend/src/main/java/com/back/ourlog/global/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/back/ourlog/global/globalExceptionHandler/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.back.ourlog.global.globalExceptionHandler;
+
+import com.back.ourlog.global.rsData.RsData;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // IllegalArgumentException
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<RsData<Void>> handleIllegalArgument(IllegalArgumentException e) {
+        return ResponseEntity
+                .badRequest()
+                .body(RsData.fail(e.getMessage()));
+    }
+
+    // @Valid 유효성 검사 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<RsData<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getFieldError() != null ?
+                e.getBindingResult().getFieldError().getDefaultMessage() :
+                "입력값이 올바르지 않습니다.";
+        return ResponseEntity
+                .badRequest()
+                .body(RsData.fail(errorMessage));
+    }
+
+    // 기타 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<RsData<Void>> handleException(Exception e) {
+        return ResponseEntity
+                .internalServerError()
+                .body(RsData.fail("서버 오류: " + e.getMessage()));
+    }
+
+    private int getHttpStatusFromCode(String code) {
+        if (code.startsWith("401")) return 401;
+        if (code.startsWith("404")) return 404;
+        if (code.startsWith("409")) return 409;
+        return 400; // 기본값
+    }
+
+}

--- a/backend/src/main/java/com/back/ourlog/global/rsData/RsData.java
+++ b/backend/src/main/java/com/back/ourlog/global/rsData/RsData.java
@@ -2,12 +2,38 @@ package com.back.ourlog.global.rsData;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class RsData<T> {
-    private final String resultCode;
-    private final String msg;
-    private final T data;
 
+    private String resultCode; // ex) 200-1, 400-2
+    private String msg;        // 사용자 메시지
+    private T data;            // 응답 데이터
+
+    public static <T> RsData<T> of(String resultCode, String msg, T data) {
+        return new RsData<>(resultCode, msg, data);
+    }
+
+    // 성공 응답
+    public static <T> RsData<T> success(T data) {
+        return new RsData<>("200-0", "성공", data);
+    }
+
+    // 실패 응답
+    public static <T> RsData<T> fail(String msg) {
+        return new RsData<>("400-0", msg, null);
+    }
+
+    // 성공 여부
+    public boolean isSuccess() {
+        return resultCode != null && resultCode.startsWith("2");
+    }
+
+    // 실패 여부
+    public boolean isFail() {
+        return !isSuccess();
+    }
 }

--- a/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
@@ -1,8 +1,10 @@
 package com.back.ourlog.domain.diary.controller;
 
+import com.back.ourlog.domain.diary.dto.DiaryWriteRequestDto;
 import com.back.ourlog.domain.diary.entity.Diary;
 import com.back.ourlog.domain.diary.repository.DiaryRepository;
 import com.back.ourlog.domain.diary.service.DiaryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +31,9 @@ class DiaryControllerTest {
 
     @Autowired
     private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private DiaryRepository diaryRepository;
@@ -70,9 +75,33 @@ class DiaryControllerTest {
                 .andExpect(jsonPath("$.data.title").value("인생 영화"));
     }
 
+    @DisplayName("감상일기 등록 실패 - 제목 없음")
+    @Test
+    void t2() throws Exception {
+        DiaryWriteRequestDto dto = new DiaryWriteRequestDto("", "내용 있음");
+
+        mvc.perform(post("/api/v1/diaries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("제목을 입력해주세요."));
+    }
+
+    @DisplayName("감상일기 등록 실패 - 내용 없음")
+    @Test
+    void t3() throws Exception {
+        DiaryWriteRequestDto dto = new DiaryWriteRequestDto("제목 있음", "");
+
+        mvc.perform(post("/api/v1/diaries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("내용을 입력해주세요."));
+    }
+
     @Test
     @DisplayName("감성일기 조회")
-    void t2() throws Exception {
+    void t4() throws Exception {
         int id = 1;
         ResultActions resultActions = mvc.perform(
                 get("/api/v1/diaries/" + id)


### PR DESCRIPTION
## 📌 과제 설명
감상일기 등록 API의 실패 케이스를 고려하여 전역 예외처리 및 테스트 코드를 추가했습니다.
모든 예외는 RsData 포맷으로 응답되며, 클라이언트가 일관된 방식으로 처리할 수 있도록 구성했습니다.

## 👩‍💻 구현 내용
GlobalExceptionHandler 클래스 추가 및 구성
@Valid 유효성 검증 실패 시 → 400 응답 + 필드별 메시지 반환
IllegalArgumentException 발생 시 → 400 응답 + 예외 메시지 반환
예상치 못한 예외 발생 시 → 500 응답 + 기본 메시지 반환
RsData.fail() 구조를 통해 응답 포맷 일관성 유지