### PR TITLE
feat(be): 좋아요 등록/취소 API 구현 (#47)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/like/controller/LikeController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/like/controller/LikeController.java
@@ -1,0 +1,28 @@
+package com.back.ourlog.domain.like.controller;
+
+import com.back.ourlog.domain.like.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/likes")
+@RequiredArgsConstructor
+
+// 좋아요 등록/취소 API 제공..
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/{diaryId}")  // 좋아요 등록..
+    public ResponseEntity<Void> like(@PathVariable Integer diaryId) {
+        likeService.like(diaryId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{diaryId}")    // 좋아요 취소..
+    public ResponseEntity<Void> unlike(@PathVariable Integer diaryId) {
+        likeService.unlike(diaryId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/like/repository/LikeRepository.java
+++ b/backend/src/main/java/com/back/ourlog/domain/like/repository/LikeRepository.java
@@ -3,7 +3,11 @@ package com.back.ourlog.domain.like.repository;
 import com.back.ourlog.domain.like.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-// 특정 일기에 달린 좋아요 수를 계산..
+
 public interface LikeRepository extends JpaRepository<Like, Integer> {
-    int countByDiaryId(Integer diaryId);
+
+    boolean existsByUserIdAndDiaryId(Integer userId, Integer diaryId);  // 특정 사용자가 일기에 좋아요를 눌렀는지 여부..
+    void deleteByUserIdAndDiaryId(Integer userId, Integer diaryId);     // 특정 사용자가 일기에 눌렀던 좋아요를 삭제..
+    int countByDiaryId(Integer diaryId);    // 특정 일기에 달린 좋아요 수를 계산..
+
 }

--- a/backend/src/main/java/com/back/ourlog/domain/like/service/LikeService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/like/service/LikeService.java
@@ -1,0 +1,42 @@
+package com.back.ourlog.domain.like.service;
+
+import com.back.ourlog.domain.diary.entity.Diary;
+import com.back.ourlog.domain.diary.repository.DiaryRepository;
+import com.back.ourlog.domain.like.entity.Like;
+import com.back.ourlog.domain.like.repository.LikeRepository;
+import com.back.ourlog.domain.user.entity.User;
+import com.back.ourlog.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final DiaryRepository diaryRepository;
+
+    private static final Integer MOCK_USER_ID = 1; // 테스트용 임시 사용자 ID..
+
+    @Transactional  // 좋아요 등록
+    public void like(Integer diaryId) {
+        if (likeRepository.existsByUserIdAndDiaryId(MOCK_USER_ID, diaryId)) {
+            return; // 이미 눌렀는지 체크
+        }
+
+        User user = userRepository.findById(MOCK_USER_ID)
+                .orElseThrow(() -> new IllegalArgumentException("유저 없음"));
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new IllegalArgumentException("다이어리 없음"));
+
+        Like like = new Like(diary, user);
+        likeRepository.save(like);
+    }
+
+    @Transactional  // 좋아요 삭제
+    public void unlike(Integer diaryId) {
+        likeRepository.deleteByUserIdAndDiaryId(MOCK_USER_ID, diaryId);
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/timeline/controller/TimelineController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/timeline/controller/TimelineController.java
@@ -18,6 +18,7 @@ public class TimelineController {
 
     @GetMapping("/timeline")
     public ResponseEntity<List<TimelineResponse>> getPublicTimeline() {
+
         return ResponseEntity.ok(timelineService.getPublicTimeline());
     }
 }

--- a/backend/src/main/java/com/back/ourlog/domain/timeline/dto/TimelineResponse.java
+++ b/backend/src/main/java/com/back/ourlog/domain/timeline/dto/TimelineResponse.java
@@ -14,6 +14,7 @@ public class TimelineResponse {
     private String imageUrl;
     private int likeCount;
     private int commentCount;
+    private boolean isLiked;
     private UserSummary user;
 
     @Getter

--- a/backend/src/main/java/com/back/ourlog/domain/timeline/repository/TimelineRepository.java
+++ b/backend/src/main/java/com/back/ourlog/domain/timeline/repository/TimelineRepository.java
@@ -6,9 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-// 공개된 일기만 최신순 가져오기..
 public interface TimelineRepository extends JpaRepository<Diary, Integer> {
 
     @Query("SELECT d FROM Diary d WHERE d.isPublic = true ORDER BY d.createdAt DESC")
-    List<Diary> findPublicDiaries();
+    List<Diary> findPublicDiaries();    // 공개된 일기만 최신순 가져오기..
 }

--- a/backend/src/main/java/com/back/ourlog/domain/timeline/service/TimelineService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/timeline/service/TimelineService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-// 공개된 일기 목록 조회, 좋아요 수, 댓글 수, 유저 정보 DTO -> 프론트 전달..
+// 공개된 일기 목록 조회, 좋아요 수, 좋아요 여부, 댓글 수, 유저 정보 DTO -> 프론트 전달..
 @Service
 @RequiredArgsConstructor
 public class TimelineService {
@@ -19,6 +19,7 @@ public class TimelineService {
     private final TimelineRepository timelineRepository;
     private final LikeRepository likeRepository;
     private final CommentRepository commentRepository;
+    private static final Integer MOCK_USER_ID = 1; // 테스트용 임시 사용자 ID..
 
     public List<TimelineResponse> getPublicTimeline() {
         List<Diary> diaries = timelineRepository.findPublicDiaries();
@@ -30,9 +31,10 @@ public class TimelineService {
                         diary.getContentText(),
                         diary.getCreatedAt().toString(),
                         diary.getContent().getPosterUrl(),
-                        likeRepository.countByDiaryId(diary.getId()),
-                        commentRepository.countByDiaryId(diary.getId()),
-                        new TimelineResponse.UserSummary(  // ✅ 유저 정보 생성
+                        likeRepository.countByDiaryId(diary.getId()),   // 좋아요 개수..
+                        commentRepository.countByDiaryId(diary.getId()),    // 댓글 개수..
+                        likeRepository.existsByUserIdAndDiaryId(MOCK_USER_ID, diary.getId()),   // 좋아요 여부..
+                        new TimelineResponse.UserSummary(
                                 diary.getUser().getId(),
                                 diary.getUser().getNickname(),
                                 diary.getUser().getProfileImageUrl()

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -24,3 +24,19 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* 카드 호버 효과 */
+.timeline-hover {
+  transition: all 0.3s ease;
+}
+
+.timeline-hover:hover {
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  transform: translateY(-5px);
+  cursor: pointer;
+}
+
+.timeline-hover:active {
+  transform: translateY(-2px) scale(0.98);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}

--- a/frontend/src/app/social/components/TimelineCard.tsx
+++ b/frontend/src/app/social/components/TimelineCard.tsx
@@ -1,59 +1,91 @@
-    "use client";
+"use client";
 
-    import { Card, Button, Image, Row, Col } from "react-bootstrap";
-    import { TimelineItem } from "../types/timeline";
-    import { FaHeart, FaComment } from "react-icons/fa";
+import { Card, Image, Row, Col } from "react-bootstrap";
+import { TimelineItem } from "../types/timeline";
+import { FaHeart, FaRegHeart, FaComment } from "react-icons/fa";
+import { useState } from "react";
 
-    interface Props {
-      item: TimelineItem;
+interface Props {
+  item: TimelineItem;
+}
+
+export default function TimelineCard({ item }: Props) {
+  const [isLiked, setIsLiked] = useState(item.isLiked);
+  const [likeCount, setLikeCount] = useState(item.likeCount);
+
+  const handleLikeClick = async () => {
+    try {
+      const response = await fetch(`/api/v1/likes/${item.id}`, {
+        method: isLiked ? "DELETE" : "POST",
+      });
+
+      if (!response.ok) throw new Error("요청 실패");
+
+      setIsLiked(!isLiked);
+      setLikeCount((prev) => (isLiked ? prev - 1 : prev + 1));
+    } catch (err) {
+      console.error("좋아요 요청 실패:", err);
+      alert("좋아요 요청 중 오류가 발생했습니다.");
     }
+  };
 
-    export default function TimelineCard({ item }: Props) {
-      return (
-        <Card className="shadow-sm rounded overflow-hidden mb-4" style={{ width: "100%", maxWidth: "360px" }}>
-          {/* 이미지 */}
-          {item.imageUrl && (
-            <Card.Img
-              variant="top"
-              src={item.imageUrl}
-              alt="Diary poster"
-              style={{ height: "200px", objectFit: "cover" }}
-            />
-          )}
+  return (
+    <Card
+      className="shadow-sm rounded overflow-hidden mb-4 timeline-hover"
+      style={{ width: "100%", maxWidth: "360px" }}
+    >
+      {item.imageUrl && (
+        <Card.Img
+          variant="top"
+          src={item.imageUrl}
+          alt="Diary poster"
+          style={{ height: "200px", objectFit: "cover" }}
+        />
+      )}
 
-          {/* 카드 본문 */}
-          <Card.Body>
-            <Card.Title className="d-flex justify-content-between align-items-center">
-              <span className="fw-bold">{item.title}</span>
-            </Card.Title>
-            <small className="text-muted">{new Date(item.createdAt).toLocaleDateString()}</small>
-          </Card.Body>
+      <Card.Body>
+        <Card.Title className="d-flex justify-content-between align-items-center">
+          <span className="fw-bold">{item.title}</span>
+        </Card.Title>
+        <small className="text-muted">
+          {new Date(item.createdAt).toLocaleDateString()}
+        </small>
+      </Card.Body>
 
-          {/* 카드 하단 */}
-          <Card.Footer className="bg-white border-0 pt-0">
-            <Row className="align-items-center text-muted">
-              <Col xs="auto" className="d-flex align-items-center gap-1">
-                <FaHeart className="text-danger" />
-                <span>{item.likeCount}</span>
-              </Col>
-              <Col xs="auto" className="d-flex align-items-center gap-1">
-                <FaComment className="text-primary" />
-                <span>{item.commentCount}</span>
-              </Col>
-              <Col className="d-flex align-items-center justify-content-end gap-2">
-                {item.user.profileImageUrl && (
-                  <Image
-                    src={item.user.profileImageUrl}
-                    roundedCircle
-                    width={28}
-                    height={28}
-                    alt="profile"
-                  />
-                )}
-                <strong className="text-dark">{item.user.nickname}</strong>
-              </Col>
-            </Row>
-          </Card.Footer>
-        </Card>
-      );
-    }
+      <Card.Footer className="bg-white border-0 pt-0">
+        <Row className="align-items-center text-muted">
+
+          {/* ❤️ 좋아요 버튼 + 숫자 */}
+          <Col xs="auto" className="d-flex align-items-center gap-1">
+            <span onClick={handleLikeClick} style={{ cursor: "pointer" }}>
+              {isLiked ? (
+                <FaHeart className="text-danger" />  // 좋아요 상태면 빨간 하트
+              ) : (
+                <FaRegHeart className="text-muted" />   // 아니라면 빈 하트
+              )}
+            </span>
+            <span>{likeCount}</span>
+          </Col>
+
+          <Col xs="auto" className="d-flex align-items-center gap-1">
+            <FaComment className="text-primary" />
+            <span>{item.commentCount}</span>
+          </Col>
+
+          <Col className="d-flex align-items-center justify-content-end gap-2">
+            {item.user.profileImageUrl && (
+              <Image
+                src={item.user.profileImageUrl}
+                roundedCircle
+                width={28}
+                height={28}
+                alt="profile"
+              />
+            )}
+            <strong className="text-dark">{item.user.nickname}</strong>
+          </Col>
+        </Row>
+      </Card.Footer>
+    </Card>
+  );
+}

--- a/frontend/src/app/social/page.tsx
+++ b/frontend/src/app/social/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import { Row, Col } from "react-bootstrap";
 import { useEffect, useState } from "react";
@@ -10,8 +10,9 @@ export default function TimelinePage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // timeline 데이터 가져오기
   useEffect(() => {
-    fetch("/api/timeline")
+    fetch("/api/v1/timeline")
       .then((res) => {
         if (!res.ok) throw new Error("Failed to fetch timeline");
         return res.json();
@@ -34,14 +35,14 @@ export default function TimelinePage() {
       {error && <p className="text-danger">{error}</p>}
 
       {!loading && !error && (
-            <Row className="g-4">
-              {items.map((item) => (
-                <Col key={item.id} xs={12} sm={6} md={4}>
-                  <TimelineCard item={item} />
-                </Col>
-              ))}
-            </Row>
-          )}
+        <Row className="g-4">
+          {items.map((item) => (
+            <Col key={item.id} xs={12} sm={6} md={4}>
+              <TimelineCard item={item} />
+            </Col>
+          ))}
+        </Row>
+      )}
     </main>
   );
 }

--- a/frontend/src/app/social/types/timeline.ts
+++ b/frontend/src/app/social/types/timeline.ts
@@ -6,6 +6,7 @@ export interface TimelineItem {
   imageUrl?: string; // 피드 카드에 이미지가 없는 경우도 있기 때문에 ?(optional)
   likeCount: number;
   commentCount: number;
+  isLiked: boolean;
   user: {
     id: number;
     nickname: string;


### PR DESCRIPTION
- 사용자가 다이어리에 좋아요를 누르거나 취소할 수 있는 API 구현
- MOCK_USER_ID 기반 임시 사용자 처리 -> 테스트 전용
- 프론트에 isLiked 상태 전달 → 하트 UI 실시간 반영
- TimelineCard에서 클릭 시 ❤️ / ♡ 토글 처리