### PR TITLE
fix(be): M:N 중간 테이블 복합키 문제 수정 (#64)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
@@ -22,6 +22,8 @@ import com.back.ourlog.domain.tag.entity.Tag;
 import com.back.ourlog.domain.tag.repository.TagRepository;
 import com.back.ourlog.domain.tag.service.TagService;
 import com.back.ourlog.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +42,9 @@ public class DiaryService {
     private final TagService tagService;
     private final GenreService genreService;
     private final OttService ottService;
+
+    @PersistenceContext
+    private EntityManager em;
 
     @Transactional
     public Diary write(DiaryWriteRequestDto req, User user) {
@@ -100,6 +105,30 @@ public class DiaryService {
 
         return DiaryResponseDto.from(diary);
     }
+
+//    @Transactional
+//    public DiaryResponseDto update(int id, DiaryUpdateRequestDto dto) {
+//        Diary diary = diaryRepository.findById(id)
+//                .orElseThrow(DiaryNotFoundException::new);
+//
+//        // 1. 기본 필드 업데이트
+//        diary.update(dto.title(), dto.contentText(), dto.rating(),
+//                dto.isPublic(), dto.externalId(), dto.type());
+//
+//        // 2. 기존 관계 제거 + flush
+//        diary.getDiaryTags().clear();
+//        diary.getDiaryGenres().clear();
+//        diary.getDiaryOtts().clear();
+//        em.flush();  // 즉시 DELETE SQL 실행 + 영속성 컨텍스트에서 detach
+//
+//        // 3. 새 관계 추가
+//        diary.updateTags(tagService.getTagsByIds(dto.tagIds()));
+//        diary.updateGenres(genreService.getGenresByIds(dto.genreIds()));
+//        diary.updateOtts(ottService.getOttsByIds(dto.ottIds()));
+//
+//        return DiaryResponseDto.from(diary);
+//    }
+
 
     public DiaryDetailDto getDiaryDetail(int diaryId) {
         Diary diary = diaryRepository.findById(diaryId).orElseThrow();

--- a/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
@@ -82,6 +82,7 @@ public class DiaryService {
         return diaryRepository.save(diary);
     }
 
+    @Transactional
     public DiaryResponseDto update(int id, DiaryUpdateRequestDto dto) {
         Diary diary = diaryRepository.findById(id)
                 .orElseThrow(DiaryNotFoundException::new);

--- a/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenre.java
+++ b/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenre.java
@@ -8,20 +8,24 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@IdClass(DiaryGenreId.class)
 public class DiaryGenre {
-    @Id
+
+    @EmbeddedId
+    private DiaryGenreId id;
+
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("diaryId")  // DiaryGenreId.diaryId와 매핑
     @JoinColumn(name = "diary_id", nullable = false)
     private Diary diary;
 
-    @Id
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("genreId")  // DiaryGenreId.genreId와 매핑
     @JoinColumn(name = "genre_id", nullable = false)
     private Genre genre;
 
     public DiaryGenre(Diary diary, Genre genre) {
         this.diary = diary;
         this.genre = genre;
+        this.id = new DiaryGenreId(diary.getId(), genre.getId()); // PK 세팅
     }
 }

--- a/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenreId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenreId.java
@@ -2,13 +2,14 @@ package com.back.ourlog.domain.genre.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 @Embeddable
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,18 +18,5 @@ public class DiaryGenreId implements Serializable {
     private Integer diaryId;
     private Integer genreId;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DiaryGenreId)) return false;
-        DiaryGenreId that = (DiaryGenreId) o;
-        return Objects.equals(diaryId, that.diaryId) &&
-                Objects.equals(genreId, that.genreId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(diaryId, genreId);
-    }
 }
 

--- a/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenreId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/genre/entity/DiaryGenreId.java
@@ -1,5 +1,6 @@
 package com.back.ourlog.domain.genre.entity;
 
+import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,23 +8,27 @@ import lombok.NoArgsConstructor;
 import java.io.Serializable;
 import java.util.Objects;
 
+@Embeddable
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class DiaryGenreId implements Serializable {
-    private Integer diary;
-    private Integer genre;
+
+    private Integer diaryId;
+    private Integer genreId;
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof DiaryGenreId)) return false;
         DiaryGenreId that = (DiaryGenreId) o;
-        return Objects.equals(diary, that.diary) && Objects.equals(genre, that.genre);
+        return Objects.equals(diaryId, that.diaryId) &&
+                Objects.equals(genreId, that.genreId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(diary, genre);
+        return Objects.hash(diaryId, genreId);
     }
 }
+

--- a/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOtt.java
+++ b/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOtt.java
@@ -8,20 +8,25 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@IdClass(DiaryOttId.class)
 public class DiaryOtt {
-    @Id
+
+    @EmbeddedId
+    private DiaryOttId id;
+
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("diaryId")  // DiaryOttId.diaryId 와 매핑
     @JoinColumn(name = "diary_id", nullable = false)
     private Diary diary;
 
-    @Id
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("ottId")  // DiaryOttId.ottId 와 매핑
     @JoinColumn(name = "ott_id", nullable = false)
     private Ott ott;
 
     public DiaryOtt(Diary diary, Ott ott) {
         this.diary = diary;
         this.ott = ott;
+        this.id = new DiaryOttId(diary.getId(), ott.getId()); // PK 세팅
     }
 }
+

--- a/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOttId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOttId.java
@@ -2,13 +2,14 @@ package com.back.ourlog.domain.ott.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 @Embeddable
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,18 +18,5 @@ public class DiaryOttId implements Serializable {
     private Integer diaryId;
     private Integer ottId;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DiaryOttId)) return false;
-        DiaryOttId that = (DiaryOttId) o;
-        return Objects.equals(diaryId, that.diaryId) &&
-                Objects.equals(ottId, that.ottId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(diaryId, ottId);
-    }
 }
 

--- a/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOttId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOttId.java
@@ -1,5 +1,6 @@
 package com.back.ourlog.domain.ott.entity;
 
+import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,23 +8,27 @@ import lombok.NoArgsConstructor;
 import java.io.Serializable;
 import java.util.Objects;
 
+@Embeddable
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class DiaryOttId implements Serializable {
-    private Integer diary;
-    private Integer ott;
+
+    private Integer diaryId;
+    private Integer ottId;
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof DiaryOttId)) return false;
         DiaryOttId that = (DiaryOttId) o;
-        return Objects.equals(diary, that.diary) && Objects.equals(ott, that.ott);
+        return Objects.equals(diaryId, that.diaryId) &&
+                Objects.equals(ottId, that.ottId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(diary, ott);
+        return Objects.hash(diaryId, ottId);
     }
 }
+

--- a/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTag.java
+++ b/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTag.java
@@ -8,21 +8,23 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@IdClass(DiaryTagId.class)
 public class DiaryTag {
+    @EmbeddedId
+    private DiaryTagId id;
 
-    @Id
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "diary_id", nullable = false)
+    @MapsId("diaryId") // DiaryTagId.diaryId 와 매핑
+    @JoinColumn(name = "diary_id")
     private Diary diary;
 
-    @Id
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "tag_id", nullable = false)
+    @MapsId("tagId") // DiaryTagId.tagId 와 매핑
+    @JoinColumn(name = "tag_id")
     private Tag tag;
 
     public DiaryTag(Diary diary, Tag tag) {
         this.diary = diary;
         this.tag = tag;
+        this.id = new DiaryTagId(diary.getId(), tag.getId()); // PK 세팅
     }
 }

--- a/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTagId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTagId.java
@@ -1,5 +1,6 @@
 package com.back.ourlog.domain.tag.entity;
 
+import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,23 +9,25 @@ import java.io.Serializable;
 import java.util.Objects;
 
 
+@Embeddable
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class DiaryTagId implements Serializable {
-    private Integer diary;
-    private Integer tag;
+    private Integer diaryId;  // FK 매핑할 ID
+    private Integer tagId;
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof DiaryTagId)) return false;
         DiaryTagId that = (DiaryTagId) o;
-        return Objects.equals(diary, that.diary) && Objects.equals(tag, that.tag);
+        return Objects.equals(diaryId, that.diaryId) && Objects.equals(tagId, that.tagId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(diary, tag);
+        return Objects.hash(diaryId, tagId);
     }
 }
+

--- a/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTagId.java
+++ b/backend/src/main/java/com/back/ourlog/domain/tag/entity/DiaryTagId.java
@@ -2,32 +2,22 @@ package com.back.ourlog.domain.tag.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 
 @Embeddable
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class DiaryTagId implements Serializable {
-    private Integer diaryId;  // FK 매핑할 ID
+
+    private Integer diaryId;
     private Integer tagId;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DiaryTagId)) return false;
-        DiaryTagId that = (DiaryTagId) o;
-        return Objects.equals(diaryId, that.diaryId) && Objects.equals(tagId, that.tagId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(diaryId, tagId);
-    }
 }
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:ourlog}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
+    username: ${MYSQL_USERNAME:root}
+    password: ${MYSQL_PASSWORD:mysq;3306}
   data:
     redis:
       host: ${REDIS_HOST}

--- a/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
@@ -3,9 +3,7 @@ package com.back.ourlog.domain.diary.controller;
 import com.back.ourlog.domain.diary.dto.DiaryWriteRequestDto;
 import com.back.ourlog.domain.diary.entity.Diary;
 import com.back.ourlog.domain.diary.repository.DiaryRepository;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,9 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 

--- a/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
@@ -116,35 +116,35 @@ class DiaryControllerTest {
                 .andExpect(jsonPath("$.data.tagNames[0]").isNotEmpty());
     }
 
-//    @Test
-//    @DisplayName("감성일기 수정 성공")
-//    void t5() throws Exception {
-//        int id = 1; // 존재하는 다이어리 ID
-//        String body = """
-//        {
-//            "title": "수정된 다이어리",
-//            "contentText": "수정된 내용입니다.",
-//            "rating": 4.0,
-//            "isPublic": true,
-//            "externalId": "MOV123456",
-//            "type": "MOVIE",
-//            "tagIds": [1, 2],
-//            "genreIds": [3],
-//            "ottIds": [1]
-//        }
-//    """;
-//
-//        mvc.perform(
-//                        put("/api/v1/diaries/" + id)
-//                                .contentType(MediaType.APPLICATION_JSON)
-//                                //.header("Authorization", "Bearer MOCK_ACCESS_TOKEN")
-//                                .content(body)
-//                ).andDo(print())
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.data.title").value("수정된 다이어리"))
-//                .andExpect(jsonPath("$.data.contentText").value("수정된 내용입니다."))
-//                .andExpect(jsonPath("$.data.rating").value(4.0));
-//    }
+    @Test
+    @DisplayName("감성일기 수정 성공")
+    void t5() throws Exception {
+        int id = 1; // 존재하는 다이어리 ID
+        String body = """
+        {
+            "title": "수정된 다이어리",
+            "contentText": "수정된 내용입니다.",
+            "rating": 4.0,
+            "isPublic": true,
+            "externalId": "MOV123456",
+            "type": "MOVIE",
+            "tagIds": [1, 2],
+            "genreIds": [3],
+            "ottIds": [1]
+        }
+    """;
+
+        mvc.perform(
+                        put("/api/v1/diaries/" + id)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                //.header("Authorization", "Bearer MOCK_ACCESS_TOKEN")
+                                .content(body)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정된 다이어리"))
+                .andExpect(jsonPath("$.data.contentText").value("수정된 내용입니다."))
+                .andExpect(jsonPath("$.data.rating").value(4.0));
+    }
 
     @Test
     @DisplayName("감성일기 수정 실패 - 존재하지 않는 ID")


### PR DESCRIPTION
**문제점**
@IdClass 방식은 복합키 필드를 별도로 들고 있고, 연관 객체와 분리되어 있음
그래서 Hibernate가 플러시(영속화) 시점과 순서 관리를 자동으로 잘 해주지 못함
즉, DiaryGenre 엔티티를 저장할 때, 내부 diary나 genre 객체가 아직 영속 상태가 아니거나, 식별자가 아직 할당되지 않은 상태면
Hibernate가 영속성 컨텍스트 내에서 같은 식별자(키) 값에 대해 서로 다른 객체가 있는 것처럼 인식 → NonUniqueObjectException 발생 가능



**방식 수정**
@EmbeddedId + @MapsId
1. 명확한 식별자 관리
복합키를 하나의 식별자 객체(@Embeddable)로 묶어서 관리하기 때문에 식별자 관리가 훨씬 깔끔해집니다.
equals(), hashCode()도 식별자 클래스 하나에서 관리하니 유지보수가 쉽습니다.

2. Hibernate 플러시(Flush) 순서 문제 완화
@MapsId를 사용하면 식별자 필드와 연관관계 필드가 연결되어, Hibernate가 내부적으로 플러시 순서를 잘 맞춰 줍니다.
@IdClass처럼 식별자와 연관관계를 분리해서 관리할 때 발생하는 NonUniqueObjectException 같은 문제를 줄여줍니다.

3. 코드 가독성 및 직관성
DiaryGenre 같은 중간 테이블 엔티티가 자신의 복합키를 하나의 필드로 갖고,
@MapsId로 연관관계가 식별자 필드와 연결되어 있다는 구조가 명확해서 이해하기 쉽고 실수할 확률이 적습니다.

4. 연관관계 편의 메서드 구현이 편리
연관된 엔티티 객체(Diary, Genre)를 직접 다루면서 자동으로 식별자(id)가 세팅되기 때문에 편리합니다.



**결론 기존 코드 수정을 최소화 하고 이 포멧으로 진행 가능**
**JPA가 복합키 관리와 플러시 순서 등 내부 처리를 좀 더 깔끔하고 자동으로**