### PR TITLE
feat(be): 감상일기 수정 API 구현 (#34)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
@@ -86,17 +86,17 @@ public class Diary {
     }
 
     public void updateTags(List<Tag> tags) {
-        this.diaryTags.removeIf(diaryTag -> true);
+        this.diaryTags.clear(); // orphanRemoval = true 이므로 DB에서도 삭제됨
         tags.forEach(tag -> this.diaryTags.add(new DiaryTag(this, tag)));
     }
 
     public void updateGenres(List<Genre> genres) {
-        this.diaryGenres.removeIf(diaryGenre -> true);
+        this.diaryGenres.clear();
         genres.forEach(genre -> this.diaryGenres.add(new DiaryGenre(this, genre)));
     }
 
     public void updateOtts(List<Ott> otts) {
-        this.diaryOtts.removeIf(diaryOtt -> true);
+        this.diaryOtts.clear();
         otts.forEach(ott -> this.diaryOtts.add(new DiaryOtt(this, ott)));
     }
 

--- a/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
@@ -88,11 +88,19 @@ public class DiaryService {
 
         // TODO: 유저 인증 로직은 이후에 추가 예정
 
+        // 기존 연관관계 완전 삭제
+        diary.getDiaryTags().clear();
+        diary.getDiaryGenres().clear();
+        diary.getDiaryOtts().clear();
+
+        // flush로 영속성 컨텍스트에서 제거
+        diaryRepository.flush();
+
         // 연관 필드 업데이트
         diary.update(dto.title(), dto.contentText(), dto.rating(),
                 dto.isPublic(), dto.externalId(), dto.type());
 
-        // N:N 관계 업데이트
+        // 연관관계 다시 설정
         diary.updateTags(tagService.getTagsByIds(dto.tagIds()));
         diary.updateGenres(genreService.getGenresByIds(dto.genreIds()));
         diary.updateOtts(ottService.getOttsByIds(dto.ottIds()));

--- a/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
@@ -116,35 +116,35 @@ class DiaryControllerTest {
                 .andExpect(jsonPath("$.data.tagNames[0]").isNotEmpty());
     }
 
-//    @Test
-//    @DisplayName("감성일기 수정 성공")
-//    void t5() throws Exception {
-//        int id = 1; // 존재하는 다이어리 ID
-//        String body = """
-//        {
-//            "title": "수정된 다이어리",
-//            "contentText": "수정된 내용입니다.",
-//            "rating": 4.0,
-//            "isPublic": true,
-//            "externalId": "MOV123456",
-//            "type": "MOVIE",
-//            "tagIds": [1, 2],
-//            "genreIds": [3],
-//            "ottIds": [1]
-//        }
-//    """;
-//
-//        mvc.perform(
-//                        put("/api/v1/diaries/" + id)
-//                                .contentType(MediaType.APPLICATION_JSON)
-//                                //.header("Authorization", "Bearer MOCK_ACCESS_TOKEN")
-//                                .content(body)
-//                ).andDo(print())
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.data.title").value("수정된 다이어리"))
-//                .andExpect(jsonPath("$.data.contentText").value("수정된 내용입니다."))
-//                .andExpect(jsonPath("$.data.rating").value(4.0));
-//    }
+    @Test
+    @DisplayName("감성일기 수정 성공")
+    void t5() throws Exception {
+        int id = 1; // 존재하는 다이어리 ID
+        String body = """
+        {
+            "title": "수정된 다이어리",
+            "contentText": "수정된 내용입니다.",
+            "rating": 4.0,
+            "isPublic": true,
+            "externalId": "MOV123456",
+            "type": "MOVIE",
+            "tagIds": [1, 2],
+            "genreIds": [3],
+            "ottIds": [1]
+        }
+    """;
+
+        mvc.perform(
+                        put("/api/v1/diaries/" + id)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                //.header("Authorization", "Bearer MOCK_ACCESS_TOKEN")
+                                .content(body)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("수정된 다이어리"))
+                .andExpect(jsonPath("$.data.contentText").value("수정된 내용입니다."))
+                .andExpect(jsonPath("$.data.rating").value(4.0));
+    }
 
     @Test
     @DisplayName("감성일기 수정 실패 - 존재하지 않는 ID")


### PR DESCRIPTION
## 📌 변경 사항

### 1. Diary 수정 시 NonUniqueObjectException 해결
- DiaryTag, DiaryGenre, DiaryOtt와 같이 복합키를 사용하는 연관관계에서,
  동일한 ID를 가진 엔티티가 세션에 중복 등록되는 문제 발생
- DiaryService.update() 내에서 기존 연관관계를 clear()한 후 flush()를 호출하여
  영속성 컨텍스트에서 완전히 제거 후 다시 매핑하도록 수정

### 2. Diary 엔티티 내부 연관관계 메서드 리팩토링
- updateTags, updateGenres, updateOtts 메서드에서 removeIf(true) → clear()로 교체
- orphanRemoval = true 설정을 활용하여 코드 가독성 및 안정성 향상


## ✅ 테스트
- DiaryControllerTest의 감상일기 수정 성공 테스트 통과 확인
- 연관관계 처리에 대한 예외 재현 방지됨