### PR TITLE
feat(be): 감상일기 삭제 API 구현 (#35)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/diary/controller/DiaryController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/controller/DiaryController.java
@@ -53,4 +53,11 @@ public class DiaryController {
         return ResponseEntity.ok(RsData.of("200-0", "일기 수정 완료", result));
     }
 
+    @DeleteMapping("/{diaryId}")
+    @Operation(summary = "감상일기 삭제", description = "감상일기를 삭제합니다.")
+    public ResponseEntity<RsData<Void>> deleteDiary(@PathVariable("diaryId") int diaryId) {
+        diaryService.delete(diaryId); // TODO: 유저 인증 붙으면 유저 추가
+        return ResponseEntity.ok(RsData.of("200-0", "일기 삭제 완료", null));
+    }
+
 }

--- a/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
@@ -22,6 +22,8 @@ import com.back.ourlog.domain.tag.entity.Tag;
 import com.back.ourlog.domain.tag.repository.TagRepository;
 import com.back.ourlog.domain.tag.service.TagService;
 import com.back.ourlog.domain.user.entity.User;
+import com.back.ourlog.global.exception.CustomException;
+import com.back.ourlog.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -116,5 +118,12 @@ public class DiaryService {
                 .toList();
 
         return new DiaryDetailDto(diary, TagNames);
+    }
+
+    public void delete(int diaryId) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
+
+        diaryRepository.delete(diary);
     }
 }

--- a/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -174,5 +175,27 @@ class DiaryControllerTest {
                 .andExpect(jsonPath("$.resultCode").value("DIARY_001"))
                 .andExpect(jsonPath("$.msg").value("존재하지 않는 다이어리입니다."));
     }
-    
+
+    @DisplayName("감상일기 삭제 성공")
+    @Test
+    void t7() throws Exception {
+        int id = 1;
+        mvc.perform(delete("/api/v1/diaries/" + id))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("일기 삭제 완료"))
+                .andExpect(jsonPath("$.resultCode").value("200-0"));
+    }
+
+    @DisplayName("감상일기 삭제 실패 - 존재하지 않는 ID")
+    @Test
+    void t8() throws Exception {
+        int id = 9999;
+        mvc.perform(delete("/api/v1/diaries/" + id))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.resultCode").value("DIARY_001"))
+                .andExpect(jsonPath("$.msg").value("존재하지 않는 다이어리입니다."));
+    }
+
 }


### PR DESCRIPTION
### ✅ 기능 구현
- 감상일기 삭제 API 구현: DELETE /api/v1/diaries/{diaryId}
- DiaryService.delete() 내에서 diary 존재 여부 확인 후 삭제 수행
- GlobalExceptionHandler와 ErrorCode를 활용하여 예외 응답 일관성 유지

### ✅ 참고
- 현재는 인증이 없는 상태로 null 유저로 처리
- 연관된 DiaryTag, DiaryGenre, DiaryOtt, Comment, Like는 orphanRemoval 설정으로 함께 삭제됨
