### PR TITLE
refactor(be): 감상일기 수정 API 리팩토링 (#79)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
     // --- OpenAPI 문서 ---
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 
     // --- Lombok ---
     compileOnly("org.projectlombok:lombok")

--- a/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryUpdateRequestDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryUpdateRequestDto.java
@@ -1,17 +1,34 @@
 package com.back.ourlog.domain.diary.dto;
 
 import com.back.ourlog.domain.content.entity.ContentType;
+import jakarta.validation.constraints.*;
 
 import java.util.List;
 
 public record DiaryUpdateRequestDto(
+        @NotBlank(message = "제목을 입력해주세요.")
         String title,
+
+        @NotBlank(message = "내용을 입력해주세요.")
         String contentText,
-        Float rating,
+
+        @NotNull
         Boolean isPublic,
+
+        @NotNull(message = "평점을 입력해주세요.")
+        @DecimalMin(value = "0.0", message = "평점은 0 이상이어야 합니다.")
+        @DecimalMax(value = "5.0", message = "평점은 5 이하이어야 합니다.")
+        Float rating,
+
+        @NotNull
         String externalId,
+
+        @NotNull
         ContentType type,
-        List<Integer> tagIds,
-        List<Integer> genreIds,
-        List<Integer> ottIds
+
+        @NotEmpty(message = "태그는 하나 이상 선택해야 합니다.")
+        List<@NotNull Integer> tagIds,
+
+        List<@NotNull Integer> genreIds,
+        List<@NotNull Integer> ottIds
 ) {}

--- a/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryWriteRequestDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryWriteRequestDto.java
@@ -2,8 +2,7 @@ package com.back.ourlog.domain.diary.dto;
 
 import java.util.List;
 import com.back.ourlog.domain.content.entity.ContentType;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 
 public record DiaryWriteRequestDto(
         @NotBlank(message = "제목을 입력해주세요.")
@@ -12,13 +11,26 @@ public record DiaryWriteRequestDto(
         @NotBlank(message = "내용을 입력해주세요.")
         String contentText,
 
-        @NotNull Boolean isPublic,
-        @NotNull Double rating,
-        @NotBlank String externalId,
-        @NotNull ContentType type,
-        List<Integer> tagIds,
-        List<Integer> genreIds,
-        List<Integer> ottIds
+        @NotNull
+        Boolean isPublic,
+
+        @NotNull(message = "평점을 입력해주세요.")
+        @DecimalMin(value = "0.0", message = "평점은 0 이상이어야 합니다.")
+        @DecimalMax(value = "5.0", message = "평점은 5 이하이어야 합니다.")
+        Float rating,
+
+        @NotNull
+        String externalId,
+
+        @NotNull
+        ContentType type,
+
+        @NotEmpty(message = "태그는 하나 이상 선택해야 합니다.")
+        List<@NotNull Integer> tagIds,
+
+        List<@NotNull Integer> genreIds,
+
+        List<@NotNull Integer> ottIds
 ) {
 
     // 테스트용 생성자
@@ -27,7 +39,7 @@ public record DiaryWriteRequestDto(
                 title,
                 contentText,
                 true,
-                4.5,
+                4.5F,
                 "external-id-test",
                 ContentType.MOVIE,
                 List.of(1, 2),

--- a/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
@@ -85,21 +85,6 @@ public class Diary {
         this.content.update(externalId, type);
     }
 
-    public void updateTags(List<Tag> tags) {
-        this.diaryTags.clear(); // orphanRemoval = true 이므로 DB에서도 삭제됨
-        tags.forEach(tag -> this.diaryTags.add(new DiaryTag(this, tag)));
-    }
-
-    public void updateGenres(List<Genre> genres) {
-        this.diaryGenres.clear();
-        genres.forEach(genre -> this.diaryGenres.add(new DiaryGenre(this, genre)));
-    }
-
-    public void updateOtts(List<Ott> otts) {
-        this.diaryOtts.clear();
-        otts.forEach(ott -> this.diaryOtts.add(new DiaryOtt(this, ott)));
-    }
-
     public Comment addComment(User user, String content) {
         Comment comment = new Comment(this, user, content);
         comments.add(comment);

--- a/backend/src/main/java/com/back/ourlog/domain/genre/entity/Genre.java
+++ b/backend/src/main/java/com/back/ourlog/domain/genre/entity/Genre.java
@@ -23,4 +23,18 @@ public class Genre {
     public Genre(String name) {
         this.name = name;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Genre)) return false;
+        Genre genre = (Genre) o;
+        return id != null && id.equals(genre.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
 }

--- a/backend/src/main/java/com/back/ourlog/domain/ott/entity/Ott.java
+++ b/backend/src/main/java/com/back/ourlog/domain/ott/entity/Ott.java
@@ -29,4 +29,18 @@ public class Ott {
         this.name = name;
         this.logoUrl = logoUrl;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Ott)) return false;
+        Ott ott = (Ott) o;
+        return id != null && id.equals(ott.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
 }

--- a/backend/src/main/java/com/back/ourlog/domain/tag/entity/Tag.java
+++ b/backend/src/main/java/com/back/ourlog/domain/tag/entity/Tag.java
@@ -23,5 +23,18 @@ public class Tag {
     public Tag(String name) {
         this.name = name;
     }
-}
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Tag)) return false;
+        Tag tag = (Tag) o;
+        return id != null && id.equals(tag.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+}

--- a/backend/src/main/java/com/back/ourlog/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/back/ourlog/global/exception/ErrorCode.java
@@ -19,6 +19,11 @@ public enum ErrorCode {
     // 다이어리 관련
     DIARY_NOT_FOUND("DIARY_001", "존재하지 않는 다이어리입니다."),
 
+    // 태그/장르/OTT 관련
+    TAG_NOT_FOUND("TAG_001", "존재하지 않는 태그입니다."),
+    GENRE_NOT_FOUND("GENRE_001", "존재하지 않는 장르입니다."),
+    OTT_NOT_FOUND("OTT_001", "존재하지 않는 OTT입니다."),
+
     // 서버/시스템 관련 (HTTP 500)
     SERVER_ERROR("SERVER_500", "서버 내부 오류가 발생했습니다."),
     DATABASE_ERROR("SERVER_501", "데이터베이스 오류가 발생했습니다."),

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -35,6 +35,12 @@ spring:
 
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
+  api-docs:
+    enabled: true
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+  override-with-generic-response: false
 
 logging:
   level:

--- a/backend/src/test/java/com/back/ourlog/domain/diary/service/DiaryServiceTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/service/DiaryServiceTest.java
@@ -64,7 +64,7 @@ class DiaryServiceTest {
                 "테스트 제목",
                 "테스트 내용",
                 true,
-                4.0,
+                4.0F,
                 "EXT123",
                 ContentType.MOVIE,
                 List.of(tag1.getId(), tag2.getId()),
@@ -95,6 +95,7 @@ class DiaryServiceTest {
     @Test
     @DisplayName("감상일기 등록 -> DiaryGenre 생성")
     void t2() throws Exception {
+        Tag dummyTag = tagRepository.save(new Tag("더미"));
 
         Genre genre1 = genreRepository.save(new Genre("스릴러"));
         Genre genre2 = genreRepository.save(new Genre("판타지"));
@@ -103,12 +104,12 @@ class DiaryServiceTest {
                 "테스트 제목",
                 "테스트 내용",
                 true,
-                4.0,
+                4.0F,
                 "EXT123",
                 ContentType.MOVIE,
-                List.of(), // tag
+                List.of(dummyTag.getId()),
                 List.of(genre1.getId(), genre2.getId()),
-                List.of()  // ott
+                List.of()
         );
 
         mockMvc.perform(post("/api/v1/diaries")
@@ -127,6 +128,7 @@ class DiaryServiceTest {
     @Test
     @DisplayName("감상일기 등록 -> DiaryOtt 생성")
     void t3() throws Exception {
+        Tag dummyTag = tagRepository.save(new Tag("더미"));
 
         Ott ott1 = ottRepository.save(new Ott("Netflix"));
         Ott ott2 = ottRepository.save(new Ott("Disney+"));
@@ -135,10 +137,10 @@ class DiaryServiceTest {
                 "테스트 제목",
                 "테스트 내용",
                 true,
-                4.0,
+                4.0F,
                 "EXT123",
                 ContentType.MOVIE,
-                List.of(), // tag
+                List.of(dummyTag.getId()),
                 List.of(), // genre
                 List.of(ott1.getId(), ott2.getId())
         );


### PR DESCRIPTION
## 📌 변경사항
기존 연관관계 clear() 후 재생성 로직에서 → 변경된 ID만 반영하는 방식으로 수정
DiaryUpdateRequestDto에 유효성 검증 어노테이션(@NotBlank, @NotNull, @DecimalMin, @DecimalMax 등) 추가
테스트 코드에서 id = 1 하드코딩 대신 diary.getId() 동적 처리로 변경
DiaryServiceTest, DiaryControllerTest 내 수정 성공/실패 케이스 보완 및 리팩토링

## 🧪 테스트
감상일기 수정 성공/실패 시나리오 모두 테스트 통과
tag, genre, ott 연관 관계 정상 반영됨 확인
등록 및 수정 시 Swagger 테스트도 정상 작동

## ⚠️ 참고 사항
DiaryWriteRequestDto의 유효성 검사 도입으로 인해 ServiceTest의 요청 객체도 수정함
Swagger 문서 오류 발생하여 application.yml에 springdoc.swagger-ui.enabled=true 등 설정함