### PR TITLE
좋아요 조회 구현 및 API 응답 리팩토링

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/like/controller/LikeController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/like/controller/LikeController.java
@@ -1,5 +1,7 @@
 package com.back.ourlog.domain.like.controller;
 
+import com.back.ourlog.domain.like.dto.LikeCountResponse;
+import com.back.ourlog.domain.like.dto.LikeResponse;
 import com.back.ourlog.domain.like.service.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,20 +11,28 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/likes")
 @RequiredArgsConstructor
 
-// 좋아요 등록/취소 API 제공..
 public class LikeController {
 
     private final LikeService likeService;
 
     @PostMapping("/{diaryId}")  // 좋아요 등록..
-    public ResponseEntity<Void> like(@PathVariable Integer diaryId) {
-        likeService.like(diaryId);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<LikeResponse> like(@PathVariable Integer diaryId) {
+        boolean liked = likeService.like(diaryId);
+        int likeCount = likeService.getLikeCount(diaryId);
+        return ResponseEntity.ok(new LikeResponse(liked, likeCount));
     }
 
     @DeleteMapping("/{diaryId}")    // 좋아요 취소..
-    public ResponseEntity<Void> unlike(@PathVariable Integer diaryId) {
+    public ResponseEntity<LikeResponse> unlike(@PathVariable Integer diaryId) {
         likeService.unlike(diaryId);
-        return ResponseEntity.ok().build();
+        int likeCount = likeService.getLikeCount(diaryId);
+        return ResponseEntity.ok(new LikeResponse(false, likeCount));
     }
+
+    @GetMapping("/count")   // 좋아요 수 단건 조회..
+    public ResponseEntity<LikeCountResponse> getLikeCount(@RequestParam Integer diaryId){
+        int count = likeService.getLikeCount(diaryId);
+        return ResponseEntity.ok(new LikeCountResponse(count));
+    }
+
 }

--- a/backend/src/main/java/com/back/ourlog/domain/like/dto/LikeCountResponse.java
+++ b/backend/src/main/java/com/back/ourlog/domain/like/dto/LikeCountResponse.java
@@ -1,0 +1,10 @@
+package com.back.ourlog.domain.like.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeCountResponse {
+    private int likeCount;
+}

--- a/backend/src/main/java/com/back/ourlog/domain/like/dto/LikeResponse.java
+++ b/backend/src/main/java/com/back/ourlog/domain/like/dto/LikeResponse.java
@@ -1,0 +1,11 @@
+package com.back.ourlog.domain.like.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeResponse {
+    private boolean liked;
+    private int likeCount;
+}

--- a/backend/src/main/java/com/back/ourlog/domain/like/service/LikeService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/like/service/LikeService.java
@@ -21,9 +21,9 @@ public class LikeService {
     private static final Integer MOCK_USER_ID = 1; // 테스트용 임시 사용자 ID..
 
     @Transactional  // 좋아요 등록
-    public void like(Integer diaryId) {
+    public boolean like(Integer diaryId) {
         if (likeRepository.existsByUserIdAndDiaryId(MOCK_USER_ID, diaryId)) {
-            return; // 이미 눌렀는지 체크
+            return false; // 이미 눌렀으면 false 반환
         }
 
         User user = userRepository.findById(MOCK_USER_ID)
@@ -33,10 +33,16 @@ public class LikeService {
 
         Like like = new Like(diary, user);
         likeRepository.save(like);
+
+        return true; // 좋아요 성공적으로 저장했으면 true
     }
 
     @Transactional  // 좋아요 삭제
     public void unlike(Integer diaryId) {
         likeRepository.deleteByUserIdAndDiaryId(MOCK_USER_ID, diaryId);
+    }
+
+    public int getLikeCount(Integer diaryId) {
+        return likeRepository.countByDiaryId(diaryId);
     }
 }

--- a/backend/src/main/java/com/back/ourlog/domain/timeline/dto/TimelineResponse.java
+++ b/backend/src/main/java/com/back/ourlog/domain/timeline/dto/TimelineResponse.java
@@ -1,5 +1,6 @@
 package com.back.ourlog.domain.timeline.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,7 +15,10 @@ public class TimelineResponse {
     private String imageUrl;
     private int likeCount;
     private int commentCount;
+
+    @JsonProperty("isLiked")
     private boolean isLiked;
+
     private UserSummary user;
 
     @Getter

--- a/frontend/src/app/social/components/TimelineCard.tsx
+++ b/frontend/src/app/social/components/TimelineCard.tsx
@@ -15,14 +15,19 @@ export default function TimelineCard({ item }: Props) {
 
   const handleLikeClick = async () => {
     try {
+      const method = isLiked ? "DELETE" : "POST";
+
       const response = await fetch(`/api/v1/likes/${item.id}`, {
-        method: isLiked ? "DELETE" : "POST",
+          method,
       });
 
-      if (!response.ok) throw new Error("요청 실패");
+      if (!response.ok) throw new Error("좋아요 요청 실패");
 
-      setIsLiked(!isLiked);
-      setLikeCount((prev) => (isLiked ? prev - 1 : prev + 1));
+      //  좋아요 후, 서버에서 최신 좋아요 수 조회
+      const data = await response.json();
+
+      setIsLiked(data.liked);
+      setLikeCount(data.likeCount);
     } catch (err) {
       console.error("좋아요 요청 실패:", err);
       alert("좋아요 요청 중 오류가 발생했습니다.");


### PR DESCRIPTION
- 좋아요 수 반환 DTO (LikeResponse) 생성
- 좋아요 단건 조회 API 개선 (GET /api/v1/likes/count?diaryId=)
- 타임라인 isLiked 값을 기반으로 프론트 하트 상태 초기 렌더링 처리
- 좋아요 요청 실패 시 UI에서 likeCount가 잘못 증가하던 문제 수정
- 프론트엔드에서 좋아요 토글 시 UI 반영 및 최신 likeCount 재조회 처리