### PR TITLE
feat(be): 타입별 그래프 데이터 조회 API 구현 (#85)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/statistics/controller/StatisticsController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/controller/StatisticsController.java
@@ -1,8 +1,7 @@
 package com.back.ourlog.domain.statistics.controller;
 
-import com.back.ourlog.domain.statistics.dto.MonthlyDiaryCount;
-import com.back.ourlog.domain.statistics.dto.StatisticsCardDto;
-import com.back.ourlog.domain.statistics.dto.TypeCountDto;
+import com.back.ourlog.domain.statistics.dto.*;
+import com.back.ourlog.domain.statistics.enums.PeriodOption;
 import com.back.ourlog.domain.statistics.service.StatisticsService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +36,12 @@ public class StatisticsController {
     public List<TypeCountDto> getTypeDistribution() {
         int userId = 1; // 임시 값, 실제로는 인증된 사용자 ID를 사용해야 합니다.
         return statisticsService.getTypeDistributionByUser(userId);
+    }
+
+    @GetMapping("/type-graph")
+    public TypeGraphResponse getTypeGraph(@RequestParam PeriodOption period) {
+        int userId = 1; // 임시 값, 실제로는 인증된 사용자 ID를 사용해야 합니다.
+        TypeGraphRequest req = new TypeGraphRequest(userId, period);
+        return statisticsService.getTypeGraph(req);
     }
 }

--- a/backend/src/main/java/com/back/ourlog/domain/statistics/dto/TypeGraphRequest.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/dto/TypeGraphRequest.java
@@ -1,0 +1,12 @@
+package com.back.ourlog.domain.statistics.dto;
+
+import com.back.ourlog.domain.statistics.enums.PeriodOption;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TypeGraphRequest {
+    private Integer userId;          // 특정 회원
+    private PeriodOption period;     // 기간 옵션
+}

--- a/backend/src/main/java/com/back/ourlog/domain/statistics/dto/TypeGraphResponse.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/dto/TypeGraphResponse.java
@@ -1,0 +1,13 @@
+package com.back.ourlog.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TypeGraphResponse {
+    private List<TypeLineGraphDto> typeLineGraph;   // 선 차트용 데이터
+    private List<TypeRankDto> typeRanking;   // 막대 차트용 데이터
+}

--- a/backend/src/main/java/com/back/ourlog/domain/statistics/dto/TypeLineGraphDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/dto/TypeLineGraphDto.java
@@ -1,0 +1,20 @@
+package com.back.ourlog.domain.statistics.dto;
+
+import com.back.ourlog.domain.content.entity.ContentType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+//@AllArgsConstructor
+public class TypeLineGraphDto {
+    private String axisLabel;        // “2025-03” 또는 “2025-03-14”
+    private ContentType type;        // DRAMA, MOVIE, BOOK, MUSIC …
+    private Long count;              // 일기 수
+
+    // 임시 생성자 직접 작성
+    public TypeLineGraphDto(String axisLabel, ContentType type, Long count) {
+        this.axisLabel = axisLabel;
+        this.type = type;
+        this.count = count;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/statistics/dto/TypeRankDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/dto/TypeRankDto.java
@@ -1,0 +1,12 @@
+package com.back.ourlog.domain.statistics.dto;
+
+import com.back.ourlog.domain.content.entity.ContentType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TypeRankDto {
+    private ContentType type;
+    private Long totalCount;
+}

--- a/backend/src/main/java/com/back/ourlog/domain/statistics/enums/PeriodOption.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/enums/PeriodOption.java
@@ -1,0 +1,9 @@
+package com.back.ourlog.domain.statistics.enums;
+
+public enum PeriodOption {
+    ALL,          // 전체
+    THIS_YEAR,    // 이번년도
+    LAST_6_MONTHS,// 최근 6개월
+    LAST_MONTH,   // 최근 1개월
+    LAST_WEEK     // 최근 1주일
+}

--- a/backend/src/main/java/com/back/ourlog/domain/statistics/repository/StatisticsRepository.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/repository/StatisticsRepository.java
@@ -15,12 +15,13 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface StatisticsRepository extends JpaRepository<Diary, Integer> {
+public interface StatisticsRepository extends JpaRepository<Diary, Integer>,StatisticsRepositoryCustom {
 
     @Query("SELECT COUNT(d) FROM Diary d WHERE d.user.id = :userId")
     long getTotalDiaryCountByUserId(@Param("userId") int userId);
 
-    @Query("SELECT AVG(d.rating) FROM Diary d WHERE d.user.id = :userId")
+    // 평균 평점 조회, 없으면 0.0 반환
+    @Query(value = "SELECT ROUND(AVG(rating), 2) FROM diary WHERE user_id = :userId", nativeQuery = true)
     Optional<Double> getAverageRatingByUserId(@Param("userId") int userId);
 
     @Query(value = """

--- a/backend/src/main/java/com/back/ourlog/domain/statistics/repository/StatisticsRepositoryCustom.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/repository/StatisticsRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.back.ourlog.domain.statistics.repository;
+
+import com.back.ourlog.domain.statistics.dto.TypeLineGraphDto;
+import com.back.ourlog.domain.statistics.dto.TypeRankDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StatisticsRepositoryCustom {
+    List<TypeLineGraphDto> findTypeLineMonthly(Integer userId, LocalDateTime start, LocalDateTime end);
+
+    List<TypeLineGraphDto> findTypeLineDaily(Integer userId, LocalDateTime start, LocalDateTime end);
+
+    List<TypeRankDto> findTypeRanking(Integer userId, LocalDateTime start, LocalDateTime end);
+}

--- a/backend/src/main/java/com/back/ourlog/domain/statistics/repository/StatisticsRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/back/ourlog/domain/statistics/repository/StatisticsRepositoryCustomImpl.java
@@ -1,0 +1,87 @@
+package com.back.ourlog.domain.statistics.repository;
+
+import com.back.ourlog.domain.content.entity.ContentType;
+import com.back.ourlog.domain.statistics.dto.TypeLineGraphDto;
+import com.back.ourlog.domain.statistics.dto.TypeRankDto;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class StatisticsRepositoryCustomImpl implements  StatisticsRepositoryCustom{
+    private final EntityManager em;
+
+    @Override
+    public List<TypeLineGraphDto> findTypeLineMonthly(Integer userId, LocalDateTime start, LocalDateTime end) {
+        String sql =
+                "SELECT " +
+                "  FORMATDATETIME(d.created_at, 'yyyy-MM') AS axisLabel, " +
+                "  c.type AS type,"+
+                "  COUNT(*) AS count " +
+                "FROM diary d " +
+                "JOIN content c ON d.content_id = c.id " +
+                "WHERE d.user_id = ? AND d.created_at BETWEEN ? AND ? " +
+                "GROUP BY axisLabel, c.type " +
+                "ORDER BY axisLabel, c.type";
+        List<Object[]> result = em.createNativeQuery(sql)
+                .setParameter(1, userId)
+                .setParameter(2, start)
+                .setParameter(3, end)
+                .getResultList();
+
+        return result.stream()
+                .map(row -> new TypeLineGraphDto(
+                        (String) row[0],
+                        ContentType.valueOf((String) row[1]),
+                        ((Number) row[2]).longValue()
+                ))
+                .toList();
+    }
+
+    @Override
+    public List<TypeLineGraphDto> findTypeLineDaily(Integer userId, LocalDateTime start, LocalDateTime end) {
+        String sql =
+                "SELECT " +
+                "  FORMATDATETIME(d.created_at, 'yyyy-MM-dd') AS axisLabel, " +
+                "  c.type AS type, " +
+                "  COUNT(*) AS count " +
+                "FROM diary d " +
+                "JOIN content c ON d.content_id = c.id " +
+                "WHERE d.user_id = ? AND d.created_at BETWEEN ? AND ? " +
+                "GROUP BY axisLabel, c.type " +
+                "ORDER BY axisLabel, c.type";
+        List<Object[]> rows = em.createNativeQuery(sql)
+                .setParameter(1, userId)
+                .setParameter(2, start)
+                .setParameter(3, end)
+                .getResultList();
+
+        return rows.stream()
+                .map(row -> new TypeLineGraphDto(
+                        (String)row[0],
+                        ContentType.valueOf((String)row[1]),
+                        ((Number)row[2]).longValue()
+                ))
+                .toList();
+    }
+
+    @Override
+    public List<TypeRankDto> findTypeRanking(Integer userId, LocalDateTime start, LocalDateTime end) {
+        String jpql =
+                "select new com.back.ourlog.domain.statistics.dto.TypeRankDto(" +
+                        "  c.type, count(d)" +
+                        ") " +
+                        "from Diary d join d.content c " +
+                        "where d.user.id = :uid and d.createdAt between :s and :e " +
+                        "group by c.type order by count(d) desc";
+        return em.createQuery(jpql, TypeRankDto.class)
+                .setParameter("uid", userId)
+                .setParameter("s",   start)
+                .setParameter("e",   end)
+                .getResultList();
+    }
+}

--- a/backend/src/test/java/com/back/ourlog/domain/statistics/contoroller/StatisticsControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/statistics/contoroller/StatisticsControllerTest.java
@@ -1,9 +1,8 @@
 package com.back.ourlog.domain.statistics.contoroller;
 
 import com.back.ourlog.domain.statistics.controller.StatisticsController;
-import com.back.ourlog.domain.statistics.dto.MonthlyDiaryCount;
-import com.back.ourlog.domain.statistics.dto.StatisticsCardDto;
-import com.back.ourlog.domain.statistics.dto.TypeCountDto;
+import com.back.ourlog.domain.statistics.dto.*;
+import com.back.ourlog.domain.statistics.enums.PeriodOption;
 import com.back.ourlog.domain.statistics.service.StatisticsService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -115,5 +114,43 @@ public class StatisticsControllerTest {
                     .andExpect(jsonPath("$.[%d].type".formatted(i)).value(typeCountDto.getType()))
                     .andExpect(jsonPath("$.[%d].count".formatted(i)).value(typeCountDto.getCount()));
         }
+    }
+
+    @Test
+    @DisplayName("타입 그래프 조회")
+    void 타입_그래프() throws Exception {
+
+        ResultActions resultActions = mvc.perform(
+                get("/api/v1/statistics/type-graph")
+                .param("userId", "1")
+                .param("period", "ALL")  // 예시로 MONTH 기간을 사용
+        ).andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(StatisticsController.class))
+                .andExpect(handler().methodName("getTypeGraph"))
+                .andExpect(status().isOk());
+
+        TypeGraphResponse typeGraphResponse = statisticsService.getTypeGraph(new TypeGraphRequest(1, PeriodOption.ALL));
+
+        List<TypeLineGraphDto> trend = typeGraphResponse.getTypeLineGraph();
+        List<TypeRankDto> ranking = typeGraphResponse.getTypeRanking();
+
+        for(int i = 0; i < trend.size(); i++) {
+            TypeLineGraphDto typeLineGraphDto = trend.get(i);
+            System.out.println("Axis Label: " + typeLineGraphDto.getAxisLabel() + ", Type: " + typeLineGraphDto.getType() + ", Count: " + typeLineGraphDto.getCount());
+            resultActions
+                    .andExpect(jsonPath("$.typeLineGraph.[%d].axisLabel".formatted(i)).value(typeLineGraphDto.getAxisLabel()))
+                    .andExpect(jsonPath("$.typeLineGraph.[%d].type".formatted(i)).value(typeLineGraphDto.getType().name()))
+                    .andExpect(jsonPath("$.typeLineGraph.[%d].count".formatted(i)).value(typeLineGraphDto.getCount()));
+        }
+        for(int i = 0; i < ranking.size(); i++) {
+            TypeRankDto typeRankDto = ranking.get(i);
+            System.out.println("Type: " + typeRankDto.getType() + ", Count: " + typeRankDto.getTotalCount());
+            resultActions
+                    .andExpect(jsonPath("$.typeRanking.[%d].type".formatted(i)).value(typeRankDto.getType().name()))
+                    .andExpect(jsonPath("$.typeRanking.[%d].totalCount".formatted(i)).value(typeRankDto.getTotalCount()));
+        }
+
     }
 }


### PR DESCRIPTION
콘텐츠 타입별 추이 그래프, 타입별 순위 그래프 API 구현