### PR TITLE
feat(fe): 공통 레이아웃 구성 (#114)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/anton": "^5.2.6",
+        "@fontsource/inter": "^5.2.6",
         "@radix-ui/react-popover": "^1.1.2",
         "@radix-ui/react-select": "^2.1.2",
         "@radix-ui/react-slot": "^1.1.0",
@@ -15,12 +17,13 @@
         "@tanstack/react-query": "^5.83.0",
         "axios": "^1.11.0",
         "bootstrap": "^5.3.7",
+        "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.468.0",
-        "next": "15.4.3",
-        "react": "19.1.0",
+        "next": "^15.4.3",
+        "react": "^19.1.0",
         "react-bootstrap": "^2.10.10",
-        "react-dom": "19.1.0",
+        "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
         "recharts": "^2.15.4",
         "tailwind-merge": "^3.3.1"
@@ -283,6 +286,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/anton": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/anton/-/anton-5.2.6.tgz",
+      "integrity": "sha512-tVKRAqItGgBVk7EkrJoLxpYwFd9PVB+KjA9lAAQKOcW+JCmqcY728182hHoOsIVoKqm210AmX6jL4N0gJ7gSAw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.6.tgz",
+      "integrity": "sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fontsource/anton": "^5.2.6",
+    "@fontsource/inter": "^5.2.6",
     "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
@@ -16,12 +18,13 @@
     "@tanstack/react-query": "^5.83.0",
     "axios": "^1.11.0",
     "bootstrap": "^5.3.7",
+    "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.468.0",
-    "next": "15.4.3",
-    "react": "19.1.0",
+    "next": "^15.4.3",
+    "react": "^19.1.0",
     "react-bootstrap": "^2.10.10",
-    "react-dom": "19.1.0",
+    "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "recharts": "^2.15.4",
     "tailwind-merge": "^3.3.1"

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@import "@fontsource/anton";
+@import "@fontsource/inter";
 
 :root {
   --background: #ffffff;
@@ -22,10 +24,19 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Inter', sans-serif; 
 }
 
-/* 카드 호버 효과 */
+.font-logo {
+  font-family: 'Anton', sans-serif;
+}
+
+a {
+  text-decoration: none !important;
+  color: inherit !important;
+  font-weight: normal;
+}
+
 .timeline-hover {
   transition: all 0.3s ease;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,9 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+import Header from "@/components/layout/Header";
+import Footer from "@/components/layout/Footer";
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -29,7 +32,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Header />
+        <main className="min-h-screen pt-24 px-4 pb-8">{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
-// src/app/page.tsx
 "use client";
+
+import React from "react";
 import TimelinePage from "./social/page";
 
 export default function Home() {

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+const Footer = () => {
+  return (
+    <footer className="bg-black text-white font-sans">
+      <div className="max-w-7xl mx-auto px-6 py-12">
+        <div className="flex flex-col space-y-2 items-start">
+          {/* 로고 및 제작자 */}
+          <h3 className="text-lg font-logo font-bold">OUR LOG</h3>
+          <p className="text-gray-400 text-sm">Made by TeamName</p>
+
+          {/* 깃허브 & 연락처 */}
+          <a
+            href="https://github.com/yeongbin1999/ourlog"
+            className="text-gray-300 hover:text-white text-sm flex items-center space-x-2"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg className="h-4 w-4 fill-current" viewBox="0 0 24 24">
+              <path d="M12 0C5.37 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 
+              11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033
+              -1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333
+              -1.756-1.089-.745.083-.729.083-.729 1.205.084
+              1.839 1.237 1.839 1.237 1.07 1.834 2.807
+              1.304 3.492.997.107-.775.418-1.305.762
+              -1.604-2.665-.305-5.467-1.334-5.467
+              -5.931 0-1.311.469-2.381 1.236
+              -3.221-.124-.303-.535-1.524.117
+              -3.176 0 0 1.008-.322 3.301
+              1.23.957-.266 1.983-.399 3.003
+              -.404 1.02.005 2.047.138 3.006
+              .404 2.291-1.552 3.297-1.23
+              3.297-1.23.653 1.653.242 2.874
+              .118 3.176.77.84 1.235 1.911
+              1.235 3.221 0 4.609-2.807
+              5.624-5.479 5.921.43.372.823
+              1.102.823 2.222v3.293c0 
+              .319.192.694.801.576C20.565 
+              21.798 24 17.302 24 12c0
+              -6.627-5.373-12-12-12z"/>
+            </svg>
+            <span>GitHub</span>
+          </a>
+
+          <a
+            href="mailto:ourlog@team.com"
+            className="text-gray-300 hover:text-white text-sm"
+          >
+            Contact us: ourlog@team.com
+          </a>
+
+          {/* 저작권 */}
+          <p className="text-gray-500 text-sm mt-6">© 2025 OurLog. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { LogIn, UserPlus } from "lucide-react";
+
+const Header = () => {
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+  const router = useRouter();
+
+  const leftNavItems = [
+    { key: "feed", label: "Feed", href: "/" },
+    { key: "diary", label: "Diary", href: "/diaries" },
+    { key: "statistics", label: "Statistics", href: "/statistics" },
+    { key: "mypage", label: "MyPage", href: "/profile/me" },
+  ];
+
+  return (
+    <header className="fixed top-0 left-0 w-full z-50 bg-white border-b border-black h-24">
+      <div className="w-full h-full flex justify-between items-center">
+        {/* 왼쪽: 로고 + 메뉴 */}
+        <div className="flex items-center pl-8 space-x-16">
+          <h1 className="text-2xl font-bold text-black font-logo">OUR LOG</h1>
+          <nav className="flex items-center space-x-4">
+            {leftNavItems.map((item) => (
+              <Link key={item.key} href={item.href} passHref>
+                <span
+                  className={`inline-block text-base px-4 py-2 rounded-full transition duration-200 ${
+                    hoveredItem === item.key
+                      ? "bg-black text-white"
+                      : "text-gray-700 hover:text-black"
+                  }`}
+                  style={{ textDecoration: "none", color: "inherit" }}
+                  onMouseEnter={() => setHoveredItem(item.key)}
+                  onMouseLeave={() => setHoveredItem(null)}
+                >
+                  {item.label}
+                </span>
+              </Link>
+            ))}
+          </nav>
+        </div>
+
+        {/* 오른쪽: 아이콘 + Write */}
+        <div className="flex items-center h-full ml-auto pr-0">
+          {/* 아이콘 툴팁 */}
+          <div className="flex items-center space-x-8 mr-6">
+            <Link href="/signup" passHref>
+              <div className="relative group cursor-pointer">
+                <UserPlus className="w-6 h-6 text-black" />
+                <div className="absolute top-full mt-1 left-1/2 -translate-x-1/2 scale-0 group-hover:scale-100 transition-transform bg-black text-white text-xs px-2 py-1 rounded whitespace-nowrap z-10">
+                  SignUp
+                </div>
+              </div>
+            </Link>
+            <Link href="/login" passHref>
+              <div className="relative group cursor-pointer">
+                <LogIn className="w-6 h-6 text-black" />
+                <div className="absolute top-full mt-1 left-1/2 -translate-x-1/2 scale-0 group-hover:scale-100 transition-transform bg-black text-white text-xs px-2 py-1 rounded whitespace-nowrap z-10">
+                  Login
+                </div>
+              </div>
+            </Link>
+          </div>
+
+          {/* Write 버튼 */}
+          <div
+            onClick={() => router.push("/diaries/write")}
+            className={`ml-6 h-full w-[180px] min-w-[160px] flex justify-center items-center cursor-pointer transition duration-200 ${
+              hoveredItem === "write"
+                ? "bg-gray-800 text-white"
+                : "bg-black text-white"
+            }`}
+            onMouseEnter={() => setHoveredItem("write")}
+            onMouseLeave={() => setHoveredItem(null)}
+          >
+            <span className="text-md">Write</span>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+    content: [
+      "./src/**/*.{js,ts,jsx,tsx}",
+      "./app/**/*.{js,ts,jsx,tsx}",
+    ],
+    theme: {
+      extend: {
+        fontFamily: {
+          sans: ["Inter", "sans-serif"],
+          logo: ["Anton", "sans-serif"],
+        },
+      },
+    },
+    plugins: [],
+  };
+  


### PR DESCRIPTION
<img width="2834" height="170" alt="화면 캡처 2025-07-31 222538" src="https://github.com/user-attachments/assets/16c252dc-5e7b-4336-9c16-cfcd485ecafb" />
<img width="2488" height="464" alt="화면 캡처 2025-07-31 222605" src="https://github.com/user-attachments/assets/558718ee-4cbf-4567-b527-9f02b002fedb" />

## ✅ 작업 내용
- 헤더 고정 처리 (fixed) 및 헤더 높이 조정 (h-24)
- main에 pt-24 적용하여 콘텐츠 가려짐 방지
- 네비게이션 Hover 스타일 개선 (black/white 전환)
- SignUp / Login 아이콘화 및 툴팁 추가 (툴팁은 아래로 표시)
- Write 버튼 우측 끝 정렬, 호버 스타일 추가
- Footer 전체 재구성:
  - 좌측 정렬 (로고, 제작자, GitHub, Contact)
  - 여백(padding) 확장, 전체 레이아웃 통일감 확보

## ✅ 기타 사항
- 추후에 네비게이션 링크 수정 필요
- write 버튼 호버 시 포인트 컬러로 변경 필요
