### PR TITLE
fix(be): DiaryControllerTest 빌드 실패 해결 (#123)

### DIFF
--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -4,3 +4,9 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true

--- a/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
@@ -102,6 +102,8 @@ class DiaryControllerTest {
     @Test
     @DisplayName("감상일기 등록 실패 - 내용 없음")
     void t3() throws Exception {
+        Tag tag = tagRepository.save(new Tag("테스트"));
+
         String body = """
         {
             "title": "제목 있음",
@@ -109,17 +111,17 @@ class DiaryControllerTest {
             "rating": 3.0,
             "isPublic": true,
             "type": "BOOK",
-            "tagIds": [1],
-            "genreIds": [1],
-            "ottIds": [1]
+            "tagIds": [3]
         }
-    """;
+    """.formatted(tag.getId());
 
         mvc.perform(post("/api/v1/diaries")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
+                .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.msg").value("내용을 입력해주세요."));
+                .andExpect(jsonPath("$.msg").value("내용을 입력해주세요."))
+                .andExpect(jsonPath("$.resultCode").value("COMMON_400"));
     }
 
     @Test


### PR DESCRIPTION
### 변경 사항
- t3() 테스트에서 '태그는 하나 이상 선택해야 합니다.' 오류 발생
- 의도한 '내용을 입력해주세요.' 메시지를 유도하기 위해 유효한 tagIds 추가
- application-test.yml에 database-platform 설정 추가하여 contextLoads 오류 해결