### PR TITLE
feat(be): 컨텐츠 검색 API 구현 (#125)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/content/controller/ContentController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/content/controller/ContentController.java
@@ -1,17 +1,19 @@
 package com.back.ourlog.domain.content.controller;
 
 import com.back.ourlog.domain.content.dto.ContentResponseDto;
+import com.back.ourlog.domain.content.dto.ContentSearchResultDto;
+import com.back.ourlog.domain.content.entity.ContentType;
 import com.back.ourlog.domain.content.service.ContentService;
+import com.back.ourlog.external.common.ContentSearchFacade;
 import com.back.ourlog.global.common.dto.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/contents")
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "컨텐츠 API")
 public class ContentController {
     private final ContentService contentService;
+    private final ContentSearchFacade contentSearchFacade;
 
     @GetMapping("/{diaryId}")
     @Operation(summary = "컨텐츠 조회")
@@ -27,5 +30,15 @@ public class ContentController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(RsData.of("200-1", "%d번 다이어리의 조회 컨텐츠가 조회되었습니다.".formatted(diaryId), res));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "컨텐츠 검색", description = "컨텐츠를 검색합니다.")
+    public ResponseEntity<RsData<List<ContentSearchResultDto>>> searchContents(
+            @RequestParam ContentType type,
+            @RequestParam String title
+    ) {
+        List<ContentSearchResultDto> results = contentSearchFacade.searchByTitle(type, title);
+        return ResponseEntity.ok(RsData.of("200-1", "콘텐츠 검색 성공", results));
     }
 }

--- a/backend/src/main/java/com/back/ourlog/external/common/ContentSearchFacade.java
+++ b/backend/src/main/java/com/back/ourlog/external/common/ContentSearchFacade.java
@@ -11,6 +11,8 @@ import com.back.ourlog.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class ContentSearchFacade {
@@ -28,6 +30,18 @@ public class ContentSearchFacade {
             };
         } catch (Exception e) {
             throw new RuntimeException("externalId로 콘텐츠 검색 중 오류 발생", e);
+        }
+    }
+
+    public List<ContentSearchResultDto> searchByTitle(ContentType type, String title) {
+        try {
+            return switch (type) {
+                case MUSIC -> spotifyService.searchMusicByTitle(title);
+                case MOVIE -> tmdbService.searchMovieByTitle(title);
+                case BOOK -> libraryService.searchBookByTitle(title);
+            };
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.CONTENT_NOT_FOUND);
         }
     }
 

--- a/backend/src/main/java/com/back/ourlog/external/spotify/dto/TrackItem.java
+++ b/backend/src/main/java/com/back/ourlog/external/spotify/dto/TrackItem.java
@@ -15,6 +15,7 @@ public class TrackItem {
     private String name;
     private List<SpotifyArtist> artists;
     private SpotifyAlbum album;
+    private int popularity;
 
     @JsonProperty("external_urls")
     private ExternalUrls externalUrls;

--- a/backend/src/main/java/com/back/ourlog/external/tmdb/dto/TmdbMovieDto.java
+++ b/backend/src/main/java/com/back/ourlog/external/tmdb/dto/TmdbMovieDto.java
@@ -24,6 +24,9 @@ public class TmdbMovieDto {
     @JsonProperty("vote_average")
     private double voteAverage;
 
+    @JsonProperty("vote_count")
+    private int voteCount;
+
     @JsonProperty("genres")
     private List<TmdbGenreDto> genres;
 

--- a/backend/src/main/java/com/back/ourlog/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/back/ourlog/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.back.ourlog.global.common.dto.RsData;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -39,6 +40,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(RsData.fail(ErrorCode.BAD_REQUEST, errorMessage));
+    }
+
+    // 필수 요청 파라미터 누락 → BAD_REQUEST
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<RsData<Void>> handleMissingServletRequestParameter(MissingServletRequestParameterException e) {
+        String paramName = e.getParameterName();
+        String message = "필수 요청 파라미터 '" + paramName + "'가 누락되었습니다.";
+
+        return ResponseEntity
+                .badRequest()
+                .body(RsData.fail(ErrorCode.BAD_REQUEST, message));
     }
 
     // 예상 못한 예외 → SERVER_ERROR

--- a/backend/src/test/java/com/back/ourlog/ApplicationTests.java
+++ b/backend/src/test/java/com/back/ourlog/ApplicationTests.java
@@ -2,7 +2,9 @@ package com.back.ourlog;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ApplicationTests {
 

--- a/backend/src/test/java/com/back/ourlog/domain/content/controller/ContentControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/content/controller/ContentControllerTest.java
@@ -1,5 +1,6 @@
 package com.back.ourlog.domain.content.controller;
 
+import com.back.ourlog.domain.content.entity.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -19,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Transactional
 class ContentControllerTest {
+
     @Autowired
     private MockMvc mvc;
 
@@ -38,4 +41,63 @@ class ContentControllerTest {
                 .andExpect(jsonPath("$.msg").value("%d번 다이어리의 조회 컨텐츠가 조회되었습니다.".formatted(diaryId)))
                 .andExpect(jsonPath("$.data.title").value("콘텐츠 30"));
     }
+
+    @Test
+    @DisplayName("컨텐츠 검색 - BOOK")
+    void t2() throws Exception {
+        mvc.perform(get("/api/v1/contents/search")
+                        .param("type", ContentType.BOOK.name())
+                        .param("title", "파과"))
+                .andDo(print())
+                .andExpect(handler().handlerType(ContentController.class))
+                .andExpect(handler().methodName("searchContents"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("콘텐츠 검색 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(lessThanOrEqualTo(10)))
+                .andExpect(jsonPath("$.data[0].type").value("BOOK"));
+    }
+
+    @Test
+    @DisplayName("컨텐츠 검색 - MOVIE")
+    void t3() throws Exception {
+        mvc.perform(get("/api/v1/contents/search")
+                        .param("type", ContentType.MOVIE.name())
+                        .param("title", "미션"))
+                .andDo(print())
+                .andExpect(handler().handlerType(ContentController.class))
+                .andExpect(handler().methodName("searchContents"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("콘텐츠 검색 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(lessThanOrEqualTo(10)))
+                .andExpect(jsonPath("$.data[0].type").value("MOVIE"));
+    }
+
+    @Test
+    @DisplayName("컨텐츠 검색 - MUSIC")
+    void t4() throws Exception {
+        mvc.perform(get("/api/v1/contents/search")
+                        .param("type", ContentType.MUSIC.name())
+                        .param("title", "Always"))
+                .andDo(print())
+                .andExpect(handler().handlerType(ContentController.class))
+                .andExpect(handler().methodName("searchContents"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("콘텐츠 검색 성공"))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(lessThanOrEqualTo(10)))
+                .andExpect(jsonPath("$.data[0].type").value("MUSIC"));
+    }
+
+    @Test
+    @DisplayName("컨텐츠 검색 - 필수 파라미터 누락 시 실패")
+    void t5() throws Exception {
+        mvc.perform(get("/api/v1/contents/search")
+                        .param("type", "BOOK")) // title 누락
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.msg").value("필수 요청 파라미터 'title'가 누락되었습니다."));
+    }
+
 }

--- a/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
@@ -111,7 +111,8 @@ class DiaryControllerTest {
             "rating": 3.0,
             "isPublic": true,
             "type": "BOOK",
-            "tagIds": [3]
+            "externalId": "library-9791190908207",
+            "tagIds": [%d]
         }
     """.formatted(tag.getId());
 


### PR DESCRIPTION
## ✅ 개요
- 감상일기 작성 시 콘텐츠 정보를 검색해서 선택할 수 있도록 `GET /api/v1/contents/search` API를 새로 추가했습니다.
- 콘텐츠 종류(`MOVIE`, `MUSIC`, `BOOK`)에 따라 외부 API를 통해 데이터를 수집하고, 서비스에서 사용하는 통일된 형태로 응답합니다.

## 🔍 콘텐츠 검색 API 구현
- `/api/v1/contents/search?type=...&title=...`
- `ContentType`(MOVIE, MUSIC, BOOK)에 따라 분기 처리
- 각각 TMDB, Spotify, 국립중앙도서관 API 연동

### 🎬 영화 (TMDB)
- TMDB 검색 → `voteCount` 기준 정렬 → 최대 10개
- 응답 정제: poster, releasedAt, genreName까지 상세 조회

### 🎵 음악 (Spotify)
- 제목 포함 필터 (`.contains()`) + 인기순 (`getPopularity`) 정렬
- 최대 10개

### 📚 책 (국립중앙도서관)
- 초기에 다양한 필터/정렬 실험
- 실제 API 응답의 품질이 일정하지 않아 정렬/필터 제거
- 최종 방식: 응답 `limit(10)` 후 바로 DTO 매핑
