### PR TITLE
feat(fe): 검색 프론트 만들기 (#134)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/user/controller/UserController.java
@@ -4,10 +4,9 @@ import com.back.ourlog.domain.user.dto.UserProfileResponse;
 import com.back.ourlog.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -27,5 +26,12 @@ public class UserController {
     public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable Integer userId) {
         UserProfileResponse profile = userService.getUserProfile(userId);
         return ResponseEntity.ok(profile);
+    }
+
+    // 닉네임에 키워드가 포함된 유저 목록을 조회하는 검색 API..
+    @GetMapping("/users/search")
+    public ResponseEntity<List<UserProfileResponse>> searchUsers(@RequestParam String keyword) {
+        List<UserProfileResponse> results = userService.searchUsersByNickname(keyword);
+        return ResponseEntity.ok(results);
     }
 }

--- a/backend/src/main/java/com/back/ourlog/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/back/ourlog/domain/user/repository/UserRepository.java
@@ -3,9 +3,13 @@ package com.back.ourlog.domain.user.repository;
 import com.back.ourlog.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByEmail(String email);
+
+    // 닉네임에 키워드가 포함된 유저를 대소문자 구분 없이 조회..
+    List<User> findByNicknameContainingIgnoreCase(String keyword);
 }

--- a/backend/src/main/java/com/back/ourlog/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/user/service/UserService.java
@@ -8,6 +8,9 @@ import com.back.ourlog.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -34,5 +37,18 @@ public class UserService {
                 user.getProfileImageUrl(),
                 user.getBio()
         );
+    }
+
+    // 검색된 유저 리스트를 프로필 응답 DTO로 변환하여 반환..
+    public List<UserProfileResponse> searchUsersByNickname(String keyword) {
+        List<User> users = userRepository.findByNicknameContainingIgnoreCase(keyword);
+        return users.stream()
+                .map(user -> new UserProfileResponse(
+                        user.getEmail(),
+                        user.getNickname(),
+                        user.getProfileImageUrl(),
+                        user.getBio()
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5697,7 +5697,6 @@
       "version": "0.468.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
       "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
-      "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,5 +4,5 @@ import React from "react";
 import TimelinePage from "./social/page";
 
 export default function Home() {
-  return <TimelinePage />;
+  return <h1>✨Welcome to OURLOG..! 12팀 화이팅..! ✨</h1>;
 }

--- a/frontend/src/app/social/page.tsx
+++ b/frontend/src/app/social/page.tsx
@@ -29,7 +29,7 @@ export default function TimelinePage() {
 
   return (
     <main className="container mt-5">
-      <h2 className="mb-4">🧾 타임라인 테스트</h2>
+      <h2 className="mb-4">🧾 타임라인 테스트..</h2>
 
       {loading && <p>⏳ 불러오는 중...</p>}
       {error && <p className="text-danger">{error}</p>}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -10,7 +10,7 @@ const Header = () => {
   const router = useRouter();
 
   const leftNavItems = [
-    { key: "feed", label: "Feed", href: "/" },
+    { key: "feed", label: "Feed", href: "/social" },
     { key: "diary", label: "Diary", href: "/diaries" },
     { key: "statistics", label: "Statistics", href: "/statistics" },
     { key: "mypage", label: "MyPage", href: "/profile/me" },
@@ -21,7 +21,11 @@ const Header = () => {
       <div className="w-full h-full flex justify-between items-center">
         {/* 왼쪽: 로고 + 메뉴 */}
         <div className="flex items-center pl-8 space-x-16">
-          <h1 className="text-2xl font-bold text-black font-logo">OUR LOG</h1>
+          <Link href="/" passHref>
+            <h1 className="text-2xl font-bold text-black font-logo cursor-pointer">
+              OUR LOG
+            </h1>
+          </Link>
           <nav className="flex items-center space-x-4">
             {leftNavItems.map((item) => (
               <Link key={item.key} href={item.href} passHref>
@@ -44,6 +48,19 @@ const Header = () => {
 
         {/* 오른쪽: 아이콘 + Write */}
         <div className="flex items-center h-full ml-auto pr-0">
+        {/* 검색창 */}
+          <div className="mr-4">
+            <input
+              type="text"
+              placeholder="Search user..."
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  router.push(`/search?keyword=${e.currentTarget.value}`);
+                }
+              }}
+              className="px-3 py-1.5 border border-gray-300 rounded-full focus:outline-none focus:ring-2 focus:ring-black text-sm"
+            />
+          </div>
           {/* 아이콘 툴팁 */}
           <div className="flex items-center space-x-8 mr-6">
             <Link href="/signup" passHref>


### PR DESCRIPTION
- 닉네임 기반 유저 검색 API 추가..
- 헤더에 검색창 추가(아직 백엔드 연동 안 했습니다.. 외형만..)
- TimelineCard -> feed 옮김..
- OURLOG 클릭 -> localhost:3000 이동..