### PR TITLE
refactor(be): Diary 리팩토링 및 OTT/캐시 관련 주요 이슈 해결

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
 
     // --- Redis ---
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
     // --- JWT ---
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/backend/src/main/java/com/back/ourlog/domain/comment/dto/CommentUpdateRequestDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/comment/dto/CommentUpdateRequestDto.java
@@ -7,6 +7,8 @@ public class CommentUpdateRequestDto {
     private int id;
     private String content;
 
+    public CommentUpdateRequestDto() {}
+
     public CommentUpdateRequestDto(int id, String content) {
         this.id = id;
         this.content = content;

--- a/backend/src/main/java/com/back/ourlog/domain/content/dto/ContentSearchResultDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/content/dto/ContentSearchResultDto.java
@@ -1,11 +1,20 @@
 package com.back.ourlog.domain.content.dto;
 
 import com.back.ourlog.domain.content.entity.ContentType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Builder;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.CLASS,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "@class"
+)
 @Builder
 public record ContentSearchResultDto(
         String externalId,
@@ -16,4 +25,26 @@ public record ContentSearchResultDto(
         LocalDateTime releasedAt,
         ContentType type,
         List<String> genres
-) {}
+) implements Serializable {
+
+    @JsonCreator
+    public ContentSearchResultDto(
+            @JsonProperty("externalId") String externalId,
+            @JsonProperty("title") String title,
+            @JsonProperty("creatorName") String creatorName,
+            @JsonProperty("description") String description,
+            @JsonProperty("posterUrl") String posterUrl,
+            @JsonProperty("releasedAt") LocalDateTime releasedAt,
+            @JsonProperty("type") ContentType type,
+            @JsonProperty("genres") List<String> genres
+    ) {
+        this.externalId = externalId;
+        this.title = title;
+        this.creatorName = creatorName;
+        this.description = description;
+        this.posterUrl = posterUrl;
+        this.releasedAt = releasedAt;
+        this.type = type;
+        this.genres = genres;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryDetailDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryDetailDto.java
@@ -4,11 +4,12 @@ import com.back.ourlog.domain.diary.entity.Diary;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Data
 @NoArgsConstructor
-public class DiaryDetailDto {
+public class DiaryDetailDto implements Serializable {
     private String title;
     private float rating;
     private String contentText;

--- a/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryDetailDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryDetailDto.java
@@ -23,6 +23,23 @@ public class DiaryDetailDto implements Serializable {
         this.contentText = diary.getContentText();
         this.tagNames = tagNames;
         this.genreNames = genreNames;
-        this.ottNames = ottNames;
+        this.ottNames = ottNames != null ? ottNames : List.of();
     }
+
+    public static DiaryDetailDto of(Diary diary) {
+        List<String> tagNames = diary.getDiaryTags().stream()
+                .map(dt -> dt.getTag().getName())
+                .toList();
+
+        List<String> genreNames = diary.getDiaryGenres().stream()
+                .map(dg -> dg.getGenre().getName())
+                .toList();
+
+        List<String> ottNames = diary.getDiaryOtts().stream()
+                .map(doo -> doo.getOtt().getName())
+                .toList();
+
+        return new DiaryDetailDto(diary, tagNames, genreNames, ottNames);
+    }
+
 }

--- a/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryResponseDto.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/dto/DiaryResponseDto.java
@@ -2,6 +2,7 @@ package com.back.ourlog.domain.diary.dto;
 
 import com.back.ourlog.domain.diary.entity.Diary;
 
+import java.io.Serializable;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -19,7 +20,8 @@ public record DiaryResponseDto(
         List<String> genres,
         List<String> tags,
         List<String> otts
-) {
+) implements Serializable {
+
     public static DiaryResponseDto from(Diary diary) {
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 

--- a/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
@@ -26,8 +26,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -139,38 +139,26 @@ public class Diary {
     }
 
     public void updateOtts(List<Integer> newOttIds, OttRepository ottRepository) {
-        if (this.getContent().getType() != ContentType.MOVIE || newOttIds == null) {
-            this.getDiaryOtts().clear();
+        if (this.getContent().getType() != ContentType.MOVIE) {
+            this.diaryOtts.clear();
             return;
         }
 
-        List<DiaryOtt> current = this.getDiaryOtts();
-        List<Integer> currentIds = current.stream()
-                .map(doo -> doo.getOtt().getId())
-                .toList();
+        if (newOttIds == null) {
+            newOttIds = new ArrayList<>();
+        }
 
-        List<DiaryOtt> toRemove = current.stream()
-                .filter(doo -> !newOttIds.contains(doo.getOtt().getId()))
-                .toList();
-        this.getDiaryOtts().removeAll(toRemove);
+        this.diaryOtts.clear();
 
-        List<Integer> toAdd = newOttIds.stream()
-                .filter(id -> !currentIds.contains(id))
-                .toList();
-
-        toAdd.forEach(id -> {
-            Ott ott = ottRepository.findById(id)
+        for (Integer ottId : newOttIds) {
+            Ott ott = ottRepository.findById(ottId)
                     .orElseThrow(() -> new CustomException(ErrorCode.OTT_NOT_FOUND));
-            this.getDiaryOtts().add(new DiaryOtt(this, ott));
-        });
+            this.diaryOtts.add(new DiaryOtt(this, ott));
+        }
     }
 
     public void setContent(Content content) {
         this.content = content;
-    }
-
-    public void clearGenres() {
-        this.getDiaryGenres().clear();
     }
 
     public Comment addComment(User user, String content) {

--- a/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/entity/Diary.java
@@ -2,11 +2,21 @@ package com.back.ourlog.domain.diary.entity;
 
 import com.back.ourlog.domain.comment.entity.Comment;
 import com.back.ourlog.domain.content.entity.Content;
+import com.back.ourlog.domain.content.entity.ContentType;
 import com.back.ourlog.domain.genre.entity.DiaryGenre;
+import com.back.ourlog.domain.genre.entity.Genre;
+import com.back.ourlog.domain.genre.service.GenreService;
 import com.back.ourlog.domain.like.entity.Like;
 import com.back.ourlog.domain.ott.entity.DiaryOtt;
+import com.back.ourlog.domain.ott.entity.Ott;
+import com.back.ourlog.domain.ott.repository.OttRepository;
 import com.back.ourlog.domain.tag.entity.DiaryTag;
+import com.back.ourlog.domain.tag.entity.Tag;
+import com.back.ourlog.domain.tag.repository.TagRepository;
 import com.back.ourlog.domain.user.entity.User;
+import com.back.ourlog.external.library.service.LibraryService;
+import com.back.ourlog.global.exception.CustomException;
+import com.back.ourlog.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -78,6 +88,81 @@ public class Diary {
         this.contentText = contentText;
         this.rating = rating;
         this.isPublic = isPublic;
+    }
+
+    public void updateTags(List<String> newTagNames, TagRepository tagRepository) {
+        List<DiaryTag> current = this.getDiaryTags();
+        List<String> currentNames = current.stream()
+                .map(dt -> dt.getTag().getName())
+                .toList();
+
+        List<DiaryTag> toRemove = current.stream()
+                .filter(dt -> !newTagNames.contains(dt.getTag().getName()))
+                .toList();
+        this.getDiaryTags().removeAll(toRemove);
+
+        List<String> toAdd = newTagNames.stream()
+                .filter(name -> !currentNames.contains(name))
+                .toList();
+
+        toAdd.forEach(tagName -> {
+            Tag tag = tagRepository.findByName(tagName)
+                    .orElseGet(() -> tagRepository.save(new Tag(tagName)));
+            this.getDiaryTags().add(new DiaryTag(this, tag));
+        });
+    }
+
+    public void updateGenres(List<String> newGenreNames, GenreService genreService, LibraryService libraryService) {
+        List<DiaryGenre> current = this.getDiaryGenres();
+        List<String> currentNames = current.stream()
+                .map(dg -> dg.getGenre().getName())
+                .toList();
+
+        ContentType contentType = this.getContent().getType();
+        List<String> mappedGenreNames = newGenreNames.stream()
+                .map(name -> contentType == ContentType.BOOK ? libraryService.mapKdcToGenre(name) : name)
+                .toList();
+
+        List<DiaryGenre> toRemove = current.stream()
+                .filter(dg -> !mappedGenreNames.contains(dg.getGenre().getName()))
+                .toList();
+        this.getDiaryGenres().removeAll(toRemove);
+
+        List<String> toAdd = mappedGenreNames.stream()
+                .filter(name -> !currentNames.contains(name))
+                .toList();
+
+        toAdd.forEach(name -> {
+            Genre genre = genreService.findOrCreateByName(name);
+            this.getDiaryGenres().add(new DiaryGenre(this, genre));
+        });
+    }
+
+    public void updateOtts(List<Integer> newOttIds, OttRepository ottRepository) {
+        if (this.getContent().getType() != ContentType.MOVIE || newOttIds == null) {
+            this.getDiaryOtts().clear();
+            return;
+        }
+
+        List<DiaryOtt> current = this.getDiaryOtts();
+        List<Integer> currentIds = current.stream()
+                .map(doo -> doo.getOtt().getId())
+                .toList();
+
+        List<DiaryOtt> toRemove = current.stream()
+                .filter(doo -> !newOttIds.contains(doo.getOtt().getId()))
+                .toList();
+        this.getDiaryOtts().removeAll(toRemove);
+
+        List<Integer> toAdd = newOttIds.stream()
+                .filter(id -> !currentIds.contains(id))
+                .toList();
+
+        toAdd.forEach(id -> {
+            Ott ott = ottRepository.findById(id)
+                    .orElseThrow(() -> new CustomException(ErrorCode.OTT_NOT_FOUND));
+            this.getDiaryOtts().add(new DiaryOtt(this, ott));
+        });
     }
 
     public void setContent(Content content) {

--- a/backend/src/main/java/com/back/ourlog/domain/diary/factory/DiaryFactory.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/factory/DiaryFactory.java
@@ -1,0 +1,40 @@
+package com.back.ourlog.domain.diary.factory;
+
+import com.back.ourlog.domain.content.entity.Content;
+import com.back.ourlog.domain.diary.entity.Diary;
+import com.back.ourlog.domain.genre.service.GenreService;
+import com.back.ourlog.domain.ott.repository.OttRepository;
+import com.back.ourlog.domain.tag.repository.TagRepository;
+import com.back.ourlog.domain.user.entity.User;
+import com.back.ourlog.external.library.service.LibraryService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DiaryFactory {
+
+    private final TagRepository tagRepository;
+    private final GenreService genreService;
+    private final OttRepository ottRepository;
+    private final LibraryService libraryService;
+
+    public Diary create(User user, Content content,
+                        String title, String contentText, Float rating, Boolean isPublic,
+                        List<String> tagNames, List<String> genreRawNames, List<Integer> ottIds) {
+
+        Diary diary = new Diary(user, content, title, contentText, rating, isPublic);
+
+        // update 메서드 재사용으로 중복 제거
+        diary.updateTags(tagNames, tagRepository);
+        if (genreRawNames != null) {
+            diary.updateGenres(genreRawNames, genreService, libraryService);
+        }
+        diary.updateOtts(ottIds, ottRepository);
+
+        return diary;
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/diary/mapper/DiaryMapper.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/mapper/DiaryMapper.java
@@ -1,0 +1,33 @@
+package com.back.ourlog.domain.diary.mapper;
+
+import com.back.ourlog.domain.diary.dto.DiaryDetailDto;
+import com.back.ourlog.domain.diary.dto.DiaryResponseDto;
+import com.back.ourlog.domain.diary.entity.Diary;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DiaryMapper {
+
+    public static DiaryResponseDto toResponseDto(Diary diary) {
+        return DiaryResponseDto.from(diary);
+    }
+
+    public static DiaryDetailDto toDetailDto(Diary diary) {
+        List<String> tagNames = diary.getDiaryTags().stream()
+                .map(diaryTag -> diaryTag.getTag().getName())
+                .toList();
+
+        List<String> genreNames = diary.getDiaryGenres().stream()
+                .map(dg -> dg.getGenre().getName())
+                .toList();
+
+        List<String> ottNames = diary.getDiaryOtts().stream()
+                .map(doo -> doo.getOtt().getName())
+                .toList();
+
+        return new DiaryDetailDto(diary, tagNames, genreNames, ottNames);
+    }
+}

--- a/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
@@ -31,7 +31,6 @@ import com.back.ourlog.global.exception.CustomException;
 import com.back.ourlog.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +38,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class DiaryService {
 
@@ -51,6 +49,7 @@ public class DiaryService {
     private final ContentSearchFacade contentSearchFacade;
     private final LibraryService libraryService;
 
+    @Transactional
     public Diary writeWithContentSearch(DiaryWriteRequestDto req, User user) {
         // 외부 콘텐츠 검색
         ContentSearchResultDto result = contentSearchFacade.search(req.type(), req.externalId());
@@ -109,7 +108,8 @@ public class DiaryService {
 
     }
 
-    @CachePut(value = "diaryDetail", key = "#p0")
+    @Transactional
+    @CacheEvict(value = "diaryDetail", key = "#p0")
     public DiaryResponseDto update(int id, DiaryUpdateRequestDto dto) {
         Diary diary = diaryRepository.findById(id)
                 .orElseThrow(DiaryNotFoundException::new);
@@ -230,6 +230,7 @@ public class DiaryService {
         });
     }
 
+    @Transactional(readOnly = true)
     @Cacheable(value = "diaryDetail", key = "#diaryId")
     public DiaryDetailDto getDiaryDetail(int diaryId) {
         Diary diary = diaryRepository.findById(diaryId)
@@ -250,6 +251,7 @@ public class DiaryService {
         return new DiaryDetailDto(diary, tagNames, genreNames, ottNames);
     }
 
+    @Transactional
     @CacheEvict(value = "diaryDetail", key = "#diaryId")
     public void delete(int diaryId) {
         Diary diary = diaryRepository.findById(diaryId)

--- a/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/service/DiaryService.java
@@ -30,6 +30,9 @@ import com.back.ourlog.external.library.service.LibraryService;
 import com.back.ourlog.global.exception.CustomException;
 import com.back.ourlog.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -106,6 +109,7 @@ public class DiaryService {
 
     }
 
+    @CachePut(value = "diaryDetail", key = "#p0")
     public DiaryResponseDto update(int id, DiaryUpdateRequestDto dto) {
         Diary diary = diaryRepository.findById(id)
                 .orElseThrow(DiaryNotFoundException::new);
@@ -226,6 +230,7 @@ public class DiaryService {
         });
     }
 
+    @Cacheable(value = "diaryDetail", key = "#diaryId")
     public DiaryDetailDto getDiaryDetail(int diaryId) {
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
@@ -245,6 +250,7 @@ public class DiaryService {
         return new DiaryDetailDto(diary, tagNames, genreNames, ottNames);
     }
 
+    @CacheEvict(value = "diaryDetail", key = "#diaryId")
     public void delete(int diaryId) {
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));

--- a/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOtt.java
+++ b/backend/src/main/java/com/back/ourlog/domain/ott/entity/DiaryOtt.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -23,5 +25,27 @@ public class DiaryOtt {
     public DiaryOtt(Diary diary, Ott ott) {
         this.diary = diary;
         this.ott = ott;
+    }
+
+    public void setDiary(Diary diary) {
+        this.diary = diary;
+    }
+
+    public void setOtt(Ott ott) {
+        this.ott = ott;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DiaryOtt)) return false;
+        DiaryOtt diaryOtt = (DiaryOtt) o;
+        return Objects.equals(diary.getId(), diaryOtt.diary.getId()) &&
+                Objects.equals(ott.getId(), diaryOtt.ott.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(diary.getId(), ott.getId());
     }
 }

--- a/backend/src/main/java/com/back/ourlog/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/back/ourlog/global/config/RedisConfig.java
@@ -1,12 +1,35 @@
 package com.back.ourlog.global.config;
 
+import com.back.ourlog.domain.content.dto.ContentSearchResultDto;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
 
+import java.time.Duration;
+
+@EnableCaching
 @Configuration
 public class RedisConfig {
 
@@ -22,4 +45,25 @@ public class RedisConfig {
         redisScript.setResultType(Long.class);
         return redisScript;
     }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory factory, ObjectMapper objectMapper) {
+        RedisSerializer<Object> jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer));
+
+        return RedisCacheManager.builder(factory)
+                .cacheDefaults(config)
+                .build();
+    }
+
 }

--- a/backend/src/main/java/com/back/ourlog/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/back/ourlog/global/config/RedisConfig.java
@@ -12,11 +12,13 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 
@@ -27,6 +29,15 @@ public class RedisConfig {
     @Bean
     public StringRedisTemplate redisTemplate(RedisConnectionFactory connectionFactory) {
         return new StringRedisTemplate(connectionFactory);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> objectRedisTemplate(RedisConnectionFactory connectionFactory, ObjectMapper objectMapper) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        return template;
     }
 
     @Bean(name = "refreshTokenRotationScript")

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -10,3 +10,6 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+
+  cache:
+    type: none

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,8 +31,14 @@ spring:
     serialization:
       fail-on-empty-beans: false
 
+
   cache:
-    type: redis
+    type: simple  # 개발/테스트용 - 메모리 캐시
+      # type: redis  # 운영용
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 2000ms
 
   data:
     redis:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,6 +31,9 @@ spring:
     serialization:
       fail-on-empty-beans: false
 
+  cache:
+    type: redis
+
   data:
     redis:
       host: localhost

--- a/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/controller/DiaryControllerTest.java
@@ -1,28 +1,22 @@
 package com.back.ourlog.domain.diary.controller;
 
-import com.back.ourlog.domain.content.entity.ContentType;
-import com.back.ourlog.domain.diary.dto.DiaryWriteRequestDto;
 import com.back.ourlog.domain.diary.entity.Diary;
 import com.back.ourlog.domain.diary.repository.DiaryRepository;
-import com.back.ourlog.domain.genre.entity.Genre;
-import com.back.ourlog.domain.genre.repository.GenreRepository;
-import com.back.ourlog.domain.ott.entity.Ott;
 import com.back.ourlog.domain.ott.repository.OttRepository;
-import com.back.ourlog.domain.tag.entity.Tag;
 import com.back.ourlog.domain.tag.repository.TagRepository;
+import com.back.ourlog.global.config.RedisConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -32,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
+@Import(RedisConfig.class)
 @Transactional
 class DiaryControllerTest {
 

--- a/backend/src/test/java/com/back/ourlog/domain/diary/service/DiaryServiceTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/service/DiaryServiceTest.java
@@ -4,12 +4,11 @@ import com.back.ourlog.domain.content.entity.ContentType;
 import com.back.ourlog.domain.diary.dto.DiaryWriteRequestDto;
 import com.back.ourlog.domain.diary.entity.Diary;
 import com.back.ourlog.domain.diary.repository.DiaryRepository;
-import com.back.ourlog.domain.genre.entity.Genre;
-import com.back.ourlog.domain.genre.repository.GenreRepository;
 import com.back.ourlog.domain.ott.entity.Ott;
 import com.back.ourlog.domain.ott.repository.OttRepository;
 import com.back.ourlog.domain.tag.entity.Tag;
 import com.back.ourlog.domain.tag.repository.TagRepository;
+import com.back.ourlog.global.config.RedisConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(RedisConfig.class)
 @Transactional
 class DiaryServiceTest {
 

--- a/frontend/src/app/diaries/[diaryId]/edit/page.tsx
+++ b/frontend/src/app/diaries/[diaryId]/edit/page.tsx
@@ -18,7 +18,7 @@ const EditDiaryPage = () => {
           fetch(`/api/v1/diaries/${diaryId}`).then(res => res.json()),
           fetch(`/api/v1/contents/${diaryId}`).then(res => res.json()),
         ]);
-
+        
         setDiary(diaryRes.data);
         setContent(contentRes.data);
       } catch (error) {
@@ -29,10 +29,21 @@ const EditDiaryPage = () => {
       }
     };
 
-    fetchDiaryAndContent();
+    if (diaryId) {
+      fetchDiaryAndContent();
+    }
   }, [diaryId]);
 
-  if (isLoading || !diary || !content) return <div>Loading...</div>;
+  if (isLoading || !diary || !content) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-8 h-8 border-2 border-black border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+          <p className="text-gray-600">데이터를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <DiaryForm
@@ -53,7 +64,7 @@ const EditDiaryPage = () => {
         rating: diary.rating,
         tagNames: diary.tagNames,
         genreNames: diary.genreNames,
-        ottNames: diary.ottNames,
+        ottNames: diary.ottNames, 
       }}
     />
   );


### PR DESCRIPTION
DiaryService 및 관련 도메인의 구조 리팩토링과 함께,
OTT 연관관계, 캐시 처리, 예외 응답 등의 문제를 전반적으로 해결했습니다.

## ✅ 주요 변경 사항

### 1. Diary.updateOtts() 리팩토링
- 수정 시 OTT 변경이 제대로 반영되지 않는 문제가 발생했음
- 복합키(@IdClass) 기반 DiaryOtt 연관관계의 삭제가 정상 동작하지 않는 문제를 clear() 방식으로 해결
- 불필요한 remove() 로직 제거, 재삽입 방식으로 일관성 확보
- OTT는 하나만 선택하기 때문에 clear() 방식으로 해결했습니다..

### 2. 존재하지 않는 OTT ID 처리 개선
- RuntimeException → CustomException(OTT_NOT_FOUND)로 변경
- 클라이언트에 400 에러 및 명확한 메시지 전달 가능
- 관련 테스트 코드(t6) 통과 확인

### 3. Redis 캐시 수동 관리 전략 도입
- DiaryService.getDiaryDetail()에서 @Cacheable 제거
- objectRedisTemplate + ObjectMapper 기반 수동 Cache-Aside 방식 적용
- RedisConfig에서 GenericJackson2JsonRedisSerializer에 타입 정보 포함 설정 적용

### 4. Diary 수정 시 캐시 자동 무효화
- DiaryService.update()에서 수정 후 Redis 캐시 key 직접 삭제 처리
- 수정 후에도 상세 페이지에 변경사항이 정확히 반영됨

## 기타
- DiaryFactory, DiaryMapper, updateGenres() 구조도 함께 개선
