### PR TITLE
feat(be): 감상일기 등록/수정/삭제 API에 인증/인가 로직 추가 (#156)

### DIFF
--- a/backend/src/main/java/com/back/ourlog/domain/diary/controller/DiaryController.java
+++ b/backend/src/main/java/com/back/ourlog/domain/diary/controller/DiaryController.java
@@ -6,7 +6,11 @@ import com.back.ourlog.domain.diary.dto.DiaryUpdateRequestDto;
 import com.back.ourlog.domain.diary.dto.DiaryWriteRequestDto;
 import com.back.ourlog.domain.diary.entity.Diary;
 import com.back.ourlog.domain.diary.service.DiaryService;
+import com.back.ourlog.domain.user.entity.User;
 import com.back.ourlog.global.common.dto.RsData;
+import com.back.ourlog.global.exception.CustomException;
+import com.back.ourlog.global.exception.ErrorCode;
+import com.back.ourlog.global.rq.Rq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -22,17 +26,19 @@ import org.springframework.web.bind.annotation.*;
 public class DiaryController {
 
     private final DiaryService diaryService;
+    private final Rq rq;
 
     @PostMapping
     @Operation(summary = "감상일기 등록", description = "감상일기를 작성합니다.")
     public ResponseEntity<RsData<DiaryResponseDto>> writeDiary(
             @Valid @RequestBody DiaryWriteRequestDto req
     ) {
-        Diary diary = diaryService.writeWithContentSearch(req, null); // TODO: 유저 인증 붙으면 'null' 대신 유저 넘기기
+        User user = rq.getCurrentUser();
+        if (user == null) throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
 
+        Diary diary = diaryService.writeWithContentSearch(req, user);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(RsData.of("201-1", "감상일기가 등록되었습니다.", DiaryResponseDto.from(diary)));
-
     }
 
     @GetMapping("/{diaryId}")
@@ -47,17 +53,23 @@ public class DiaryController {
     @PutMapping("/{diaryId}")
     @Operation(summary = "감상일기 수정", description = "감상일기를 수정합니다.")
     public ResponseEntity<RsData<DiaryResponseDto>> updateDiary(
-            @PathVariable("diaryId") int diaryId,
+            @PathVariable int diaryId,
             @Valid @RequestBody DiaryUpdateRequestDto req
     ) {
-        DiaryResponseDto result = diaryService.update(diaryId, req); // TODO: 유저 인증 붙으면 유저 추가
+        User user = rq.getCurrentUser();
+        if (user == null) throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
+
+        DiaryResponseDto result = diaryService.update(diaryId, req, user);
         return ResponseEntity.ok(RsData.of("200-0", "일기 수정 완료", result));
     }
 
     @DeleteMapping("/{diaryId}")
     @Operation(summary = "감상일기 삭제", description = "감상일기를 삭제합니다.")
-    public ResponseEntity<RsData<Void>> deleteDiary(@PathVariable("diaryId") int diaryId) {
-        diaryService.delete(diaryId); // TODO: 유저 인증 붙으면 유저 추가
+    public ResponseEntity<RsData<Void>> deleteDiary(@PathVariable int diaryId) {
+        User user = rq.getCurrentUser();
+        if (user == null) throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
+
+        diaryService.delete(diaryId, user);
         return ResponseEntity.ok(RsData.of("200-0", "일기 삭제 완료", null));
     }
 

--- a/backend/src/main/java/com/back/ourlog/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/back/ourlog/global/security/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.back.ourlog.global.security.oauth.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -39,9 +40,18 @@ public class SecurityConfig {
                 .headers(headers -> headers.contentSecurityPolicy(csp -> csp.policyDirectives("frame-ancestors 'self'")))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/oauth2/**").permitAll()
+                        .requestMatchers(
+                                "/api/v1/auth/signup",
+                                "/api/v1/auth/login",
+                                "/api/v1/auth/reissue",
+                                "/oauth2/**").permitAll()
+                        // 다이어리 조회(GET)은 모두 허용
+                        .requestMatchers(HttpMethod.GET, "/api/v1/diaries/**").permitAll()
+
+                        // 나머지 다이어리 관련 요청은 USER만
+                        .requestMatchers("/api/v1/diaries/**").hasRole("USER")
+
                         .requestMatchers("/api/v1/auth/logout").authenticated()
-//                        .anyRequest().authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/backend/src/test/java/com/back/ourlog/domain/diary/service/DiaryServiceTest.java
+++ b/backend/src/test/java/com/back/ourlog/domain/diary/service/DiaryServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,6 +53,7 @@ class DiaryServiceTest {
     private ObjectMapper objectMapper;
 
     @Test
+    @WithUserDetails("user1@test.com")
     @DisplayName("감상일기 등록 → DiaryTag 생성")
     void t1() throws Exception {
         DiaryWriteRequestDto requestDto = new DiaryWriteRequestDto(
@@ -80,6 +82,7 @@ class DiaryServiceTest {
     }
 
     @Test
+    @WithUserDetails("user1@test.com")
     @DisplayName("감상일기 등록 → 외부 API 기반 DiaryGenre 자동 생성")
     void t2() throws Exception {
         tagRepository.save(new Tag("더미"));
@@ -107,6 +110,7 @@ class DiaryServiceTest {
     }
 
     @Test
+    @WithUserDetails("user1@test.com")
     @DisplayName("감상일기 등록 → DiaryOtt 생성")
     void t3() throws Exception {
         tagRepository.save(new Tag("더미"));


### PR DESCRIPTION
- SecurityConfig에 /api/v1/diaries/** 요청 USER 권한 필요하도록 설정
- 게시물 조회(GET /api/v1/diaries/{id})는 인증 없이 접근 가능하도록 예외 처리
- DiaryController 작성/수정/삭제 API에 인증 사용자 확인 로직 추가 (Rq.getCurrentUser 활용)
- DiaryService에서 작성/수정/삭제 시 작성자 검증 로직 유지
- DiaryService 조회 API에 비공개 글 접근 제한 로직 추가
- 테스트 코드에 @WithUserDetails 적용하여 인증 우회
- 테스트 환경에서 Redis 연결 문제 해결을 위해 로컬 Redis 사용
